### PR TITLE
STMicro NFC Class Extension code review  rc2

### DIFF
--- a/nfc/libs/NfcCoreLib/inc/phNfcTypes.h
+++ b/nfc/libs/NfcCoreLib/inc/phNfcTypes.h
@@ -238,10 +238,8 @@ typedef struct phNfc_sDeviceCapabilities
 
     struct
     {
-        uint8_t Byte0;                      /**< Byte 0*/
-        uint8_t Byte1;                      /**< Byte 1*/
-        uint8_t Byte2;                      /**< Byte 2*/
-        uint8_t Byte3;                      /**< Byte 3*/
+        uint8_t Length;
+        uint8_t *Buffer;                    /**<Manufacturer information NCI*/
     } ManufactureInfo;
 
     struct

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc.c
@@ -2291,14 +2291,10 @@ NFCSTATUS phLibNfc_Mgt_GetstackCapabilities(phLibNfc_StackCapabilities_t* phLibN
         phLibNfc_StackCapabilities->psDevCapabilities.ManufacturerId =
             PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufacturerId;
         
-        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Byte0 =
-            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Byte0;
-        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Byte1 =
-            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Byte1;
-        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Byte2 =
-            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Byte2;
-        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Byte3 =
-            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Byte3;
+        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Length =
+            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Length;
+        phLibNfc_StackCapabilities->psDevCapabilities.ManufactureInfo.Buffer =
+            PHLIBNFC_GETCONTEXT()->tNfccFeatures.ManufactureInfo.Buffer;
 
         phLibNfc_StackCapabilities->psDevCapabilities.PowerStateInfo.SwitchOffState =
             PHLIBNFC_GETCONTEXT()->tNfccFeatures.PowerStateInfo.SwitchOffState;

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Discovery.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Discovery.c
@@ -1292,7 +1292,7 @@ static void phLibNfc_SetDiscPayload(void *pContext,phLibNfc_sADD_Cfg_t *pADDSetu
         pNciConfig->EnableKovio = pADDSetup->PollDevInfo.PollCfgInfo.EnableKovio;
     }
     /* Configure for P2P Initiator Device */
-    /* Enable passive mode */
+    /* Enable active mode */
     if(pADDSetup->PollDevInfo.PollCfgInfo.EnableNfcActive == 1)
     {
         pNciConfig->PollNfcAActive = 0;

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Hci.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Hci.c
@@ -47,8 +47,8 @@ phLibNfc_Sequence_t gphLibNfc_HciInitSequence[] = {
 };
 
 phLibNfc_Sequence_t gphLibNfc_HciChildDevInitSequence[] = {
-    {&phLibNfc_NfceeModeSet, &phLibNfc_NfceeModeSetProc},
     {&phLibNfc_HciSetWhiteList, &phLibNfc_HciSetWhiteListProc},
+    {&phLibNfc_NfceeModeSet, &phLibNfc_NfceeModeSetProc},
     {NULL, &phLibNfc_HciChildDevInitComplete}
 };
 

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
@@ -37,9 +37,10 @@ phLibNfc_Sequence_t gphLibNfc_InitializeSequence[] = {
 
 static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
 {
-    pphLibNfc_LibContext_t      pLibContext=NULL;
+    pphLibNfc_LibContext_t      pLibContext = NULL;
     pphNciNfc_Context_t         pNciContext = NULL;
-    pphNciNfc_TransactInfo_t pTransactInfo=(pphNciNfc_TransactInfo_t)pInfo;
+    pphHciNfc_HciContext_t      pHciContext = NULL;
+    pphNciNfc_TransactInfo_t pTransactInfo = (pphNciNfc_TransactInfo_t)pInfo;
     NFCSTATUS tempStatus = wStatus;
 
     PH_LOG_LIBNFC_FUNC_ENTRY();
@@ -103,6 +104,19 @@ static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
                                 phNciNfc_e_RegisterReset,\
                                 &phLibNfc_ResetNtfHandler,\
                                 (void *)gpphLibNfc_Context);
+                    }
+
+                    /*The Static HCI Connection exists after NFCC initialization without needing to be
+                    *created using the connection Control Messages defined in Section 4.4.2 and is never closed
+                    */
+                    if (pLibContext->pHciContext == NULL && pNciContext->InitRspParams.DataHCIPktPayloadLen > 0)
+                    {
+                        pHciContext = (phHciNfc_HciContext_t*)phOsalNfc_GetMemory(sizeof(phHciNfc_HciContext_t));
+                        pLibContext->pHciContext = pHciContext;
+                        phOsalNfc_SetMemory(pHciContext, 0, sizeof(phHciNfc_HciContext_t));
+                        pHciContext->pNciContext = pLibContext->sHwReference.pNciHandle;
+                        pLibContext->tSeInfo.bSeState[phLibNfc_SE_Index_HciNwk] = phLibNfc_SeStateInitializing;
+                        pLibContext->sSeContext.pActiveSeInfo = (pphLibNfc_SE_List_t)(&pLibContext->tSeInfo.tSeList[phLibNfc_SE_Index_HciNwk]);
                     }
 
                     /* RF_ISO_DEP_NAK_PRESENCE_CMD and CORE_SET_POWER_SUB_STATE_CMD are NCI2.0 commands.

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
@@ -38,6 +38,7 @@ phLibNfc_Sequence_t gphLibNfc_InitializeSequence[] = {
 static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
 {
     pphLibNfc_LibContext_t      pLibContext=NULL;
+    pphNciNfc_Context_t         pNciContext = NULL;
     pphNciNfc_TransactInfo_t pTransactInfo=(pphNciNfc_TransactInfo_t)pInfo;
     NFCSTATUS tempStatus = wStatus;
 
@@ -52,6 +53,7 @@ static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
             if(NULL != pInfo)
             {
                 (PHLIBNFC_GETCONTEXT())->sHwReference.pNciHandle=pTransactInfo->pContext;
+                pNciContext = pTransactInfo->pContext;
 
                 wStatus = phLibNfc_GetNfccFeatures((PHLIBNFC_GETCONTEXT())->sHwReference.pNciHandle);
                 if(NFCSTATUS_SUCCESS == wStatus)
@@ -101,6 +103,15 @@ static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
                                 phNciNfc_e_RegisterReset,\
                                 &phLibNfc_ResetNtfHandler,\
                                 (void *)gpphLibNfc_Context);
+                    }
+
+                    /* RF_ISO_DEP_NAK_PRESENCE_CMD and CORE_SET_POWER_SUB_STATE_CMD are NCI2.0 commands.
+                     * If the Nci Version is 2.0 force those flags to 1.
+                     */
+                    if (PH_NCINFC_VERSION_IS_2x(pNciContext))
+                    {
+                        pLibContext->Config.bIsoDepPresChkCmd = 1;
+                        pLibContext->Config.bSwitchedOnSubState = 1;
                     }
                 }else
                 {

--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_State.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_State.c
@@ -611,6 +611,15 @@ static NFCSTATUS phLibNfc_DummyFunc(void *pContext, void *Param1, void *Param2, 
  
                 if(NULL != (void *)pSeHandle)
                 {
+                    for (bIndex = 0; bIndex < PHHCINFC_TOTAL_NFCEES; bIndex++)
+                    {
+                        if (pSeHandle == pLibContext->tSeInfo.tSeList[bIndex].hSecureElement)
+                        {
+                            pLibContext->sSeContext.pActiveSeInfo = &pLibContext->tSeInfo.tSeList[bIndex];
+                            break;
+                        }
+                    }
+
                     if(PH_NCINFC_EXT_NFCEEMODE_DISABLE == eNfceeMode)
                     {
                         pSetModeSeq = gphLibNfc_SetSeModeSeq;
@@ -624,14 +633,6 @@ static NFCSTATUS phLibNfc_DummyFunc(void *pContext, void *Param1, void *Param2, 
                         eNfceeMode = PH_NCINFC_EXT_NFCEEMODE_ENABLE;
                     }
 
-                    for(bIndex = 0; bIndex < PHHCINFC_TOTAL_NFCEES; bIndex++)
-                    {
-                        if( pSeHandle == pLibContext->tSeInfo.tSeList[bIndex].hSecureElement)
-                        {
-                            pLibContext->sSeContext.pActiveSeInfo = &pLibContext->tSeInfo.tSeList[bIndex];
-                            break;
-                        }
-                    }
                     pLibContext->sSeContext.eNfceeMode = eNfceeMode;
 
                     /* If there is no sequence existing to execute, return SUCCESS asuming that

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -288,6 +288,10 @@ NFCSTATUS phNciNfc_StartDiscovery(void* pNciHandle,
     NFCSTATUS               wStatus = NFCSTATUS_SUCCESS;
     /* Store the Number of Discovery configurations */
     uint8_t bNoofConfigs=0;
+    bool_t bNci1x = PH_NCINFC_VERSION_IS_1x(pNciContext);
+    bool_t bNci2x = PH_NCINFC_VERSION_IS_2x(pNciContext);
+
+    /*Note: ListenNfcFActive and PollNfcFActive exist only in NCI1.x specification.*/
 
     PH_LOG_NCI_FUNC_ENTRY();
     if(NULL == pNciHandle)
@@ -344,22 +348,24 @@ NFCSTATUS phNciNfc_StartDiscovery(void* pNciHandle,
             bNoofConfigs++;
         }
         /* Check whether Polling loop to be enabled for Listen NFC-F Technology */
-        if(pPollConfig->ListenNfcAActive)
+        if(pPollConfig->ListenNfcAActive ||
+            (1 == pPollConfig->ListenNfcFActive && bNci2x))
         {
             bNoofConfigs++;
         }
         /* Check whether Polling loop to be enabled for Listen NFC-F Technology */
-        if(pPollConfig->ListenNfcFActive)
+        if(pPollConfig->ListenNfcFActive && bNci1x)
         {
             bNoofConfigs++;
         }
         /* Check whether Polling loop to be enabled for Listen NFC-F Technology */
-        if(pPollConfig->PollNfcAActive)
+        if(pPollConfig->PollNfcAActive ||
+            (1 == pPollConfig->PollNfcFActive && bNci2x))
         {
             bNoofConfigs++;
         }
         /* Check whether Polling loop to be enabled for Listen NFC-F Technology */
-        if(pPollConfig->PollNfcFActive)
+        if(pPollConfig->PollNfcFActive && bNci1x)
         {
             bNoofConfigs++;
         }

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -1715,10 +1715,9 @@ NFCSTATUS phNciNfc_GetNfccFeatures(void *pNciCtx,
         /* Store the Manufacturer ID */
         pNfccFeatures->ManufacturerId = pNciContext->InitRspParams.ManufacturerId;
         /* Store the Manufacturer specific info */
-        pNfccFeatures->ManufactureInfo.Byte0 = pNciContext->InitRspParams.ManufacturerInfo.Byte0;
-        pNfccFeatures->ManufactureInfo.Byte1 = pNciContext->InitRspParams.ManufacturerInfo.Byte1;
-        pNfccFeatures->ManufactureInfo.Byte2 = pNciContext->InitRspParams.ManufacturerInfo.Byte2;
-        pNfccFeatures->ManufactureInfo.Byte3 = pNciContext->InitRspParams.ManufacturerInfo.Byte3;
+        pNfccFeatures->ManufactureInfo.Length = pNciContext->InitRspParams.ManufacturerInfo.Length;
+        pNfccFeatures->ManufactureInfo.Buffer = pNciContext->InitRspParams.ManufacturerInfo.Buffer;
+
         /* Store the version Number */
         pNfccFeatures->NciVer = pNciContext->ResetInfo.NciVer;
         /* Store the maximum routing table size */
@@ -2050,6 +2049,12 @@ phNciNfc_ReleaseNciHandle(void )
                 phOsalNfc_FreeMemory(pNciCtx->tSendPayload.pBuff);
                 pNciCtx->tSendPayload.pBuff = NULL;
                 pNciCtx->tSendPayload.wPayloadSize = 0;
+            }
+
+            if (NULL != pNciCtx->InitRspParams.ManufacturerInfo.Buffer) {
+                phOsalNfc_FreeMemory(pNciCtx->InitRspParams.ManufacturerInfo.Buffer);
+                pNciCtx->InitRspParams.ManufacturerInfo.Buffer = NULL;
+                pNciCtx->InitRspParams.ManufacturerInfo.Length = 0;
             }
 
             phNciNfc_ReleaseNfceeCntx();

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -32,6 +32,8 @@
 #define PH_NCINFC_VERSION_IS_1x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <= \
                                                      (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
 #define PH_NCINFC_VERSION_2x                        ((PH_NCINFC_VERSION_MAJOR_2x << 4) | PH_NCINFC_VERSION_MINOR_2x)
+#define PH_NCINFC_VERSION_IS_2x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) == \
+                                                     (PH_NCINFC_VERSION_2x & PH_NCINFC_VERSION_MAJOR_MASK))
 
 
 

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -25,10 +25,14 @@
 
 #define PH_NCINFC_VERSION_MAJOR_1x                  (0x01)
 #define PH_NCINFC_VERSION_MINOR_1x                  (0x00)
+#define PH_NCINFC_VERSION_MAJOR_2x                  (0x02)
+#define PH_NCINFC_VERSION_MINOR_2x                  (0x00)
 
 #define PH_NCINFC_VERSION_1x                        ((PH_NCINFC_VERSION_MAJOR_1x << 4) | PH_NCINFC_VERSION_MINOR_1x)
 #define PH_NCINFC_VERSION_IS_1x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <= \
                                                      (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
+#define PH_NCINFC_VERSION_2x                        ((PH_NCINFC_VERSION_MAJOR_2x << 4) | PH_NCINFC_VERSION_MINOR_2x)
+
 
 
 /**

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -23,10 +23,10 @@
 #define PH_NCINFC_VERSION_MAJOR_MASK                (0xF0)
 #define PH_NCINFC_VERSION_MINOR_MASK                (0x0F)
 
-#define PH_NCINFC_VERSION_MAJOR                     (0x01)
-#define PH_NCINFC_VERSION_MINOR                     (0x00)
+#define PH_NCINFC_VERSION_MAJOR_1x                  (0x01)
+#define PH_NCINFC_VERSION_MINOR_1x                  (0x00)
 
-#define PH_NCINFC_VERSION                           ((PH_NCINFC_VERSION_MAJOR << 4) | PH_NCINFC_VERSION_MINOR)
+#define PH_NCINFC_VERSION_1x                        ((PH_NCINFC_VERSION_MAJOR_1x << 4) | PH_NCINFC_VERSION_MINOR_1x)
 
 
 /**

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -27,6 +27,8 @@
 #define PH_NCINFC_VERSION_MINOR_1x                  (0x00)
 
 #define PH_NCINFC_VERSION_1x                        ((PH_NCINFC_VERSION_MAJOR_1x << 4) | PH_NCINFC_VERSION_MINOR_1x)
+#define PH_NCINFC_VERSION_IS_1x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <= \
+                                                     (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
 
 
 /**

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -1143,10 +1143,8 @@ typedef struct phNciNfc_NfccFeatures
     uint8_t ManufacturerId;
     struct
     {
-        uint8_t Byte0;                      /**< Byte 0 */
-        uint8_t Byte1;                      /**< Byte 1 */
-        uint8_t Byte2;                      /**< Byte 2 */
-        uint8_t Byte3;                      /**< Byte 3 */
+        uint8_t Length;
+        uint8_t *Buffer;                    /**<Manufacturer information NCI*/
     }ManufactureInfo;
 }phNciNfc_NfccFeatures_t, *pphNciNfc_NfccFeatures_t;/**< pointer to #phNciNfc_NfccFeatures_t */
 

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -18,27 +18,6 @@
 
 /**
  * \ingroup grp_nci_nfc
- * \brief The supported NCI version of the specification
- */
-#define PH_NCINFC_VERSION_MAJOR_MASK                (0xF0)
-#define PH_NCINFC_VERSION_MINOR_MASK                (0x0F)
-
-#define PH_NCINFC_VERSION_MAJOR_1x                  (0x01)
-#define PH_NCINFC_VERSION_MINOR_1x                  (0x00)
-#define PH_NCINFC_VERSION_MAJOR_2x                  (0x02)
-#define PH_NCINFC_VERSION_MINOR_2x                  (0x00)
-
-#define PH_NCINFC_VERSION_1x                        ((PH_NCINFC_VERSION_MAJOR_1x << 4) | PH_NCINFC_VERSION_MINOR_1x)
-#define PH_NCINFC_VERSION_IS_1x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <= \
-                                                     (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
-#define PH_NCINFC_VERSION_2x                        ((PH_NCINFC_VERSION_MAJOR_2x << 4) | PH_NCINFC_VERSION_MINOR_2x)
-#define PH_NCINFC_VERSION_IS_2x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) == \
-                                                     (PH_NCINFC_VERSION_2x & PH_NCINFC_VERSION_MAJOR_MASK))
-
-
-
-/**
- * \ingroup grp_nci_nfc
  * \brief Max length of Higher layer inf of ATTRIB command
  */
 #define PH_NCINFC_MAX_HIGHER_LAYER_INF_LEN           (0x30U)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Context.h
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Context.h
@@ -46,7 +46,7 @@ typedef struct phNciNfc_Context
     phNciNfc_LstnModeRecvInfo_t tLstnModeRecvInfo;  /**<Holds information Data if received before
                                                         application invokes "RemoteDev_Receive" API  in listen mode*/
     void *pUpperLayerInfo;                      /**< Used to store data pointer of Upper layer */
-    uint32_t dwNtfTimerId;                      /**< Timer for to handle Reactivate NTF*/
+    uint32_t dwNtfTimerId;                      /**< Timer for to handle NTF*/
     phNciNfc_SeEventList_t  tSeEventList;       /**< Structure holding Se event registrations*/
 }phNciNfc_Context_t, *pphNciNfc_Context_t;      /**< pointer to #phNciNfc_Context_t structure */
 

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Discovery.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Discovery.c
@@ -1071,9 +1071,14 @@ NFCSTATUS phNciNfc_UpdateDiscConfigParams(void *pNciHandle,
     pphNciNfc_Context_t     pNciContext = pNciHandle;
     /* Index to construct discover command payload */
     uint8_t bIndex=1;
+    bool_t bNci1x = PH_NCINFC_VERSION_IS_1x(pNciContext);
+    bool_t bNci2x = PH_NCINFC_VERSION_IS_2x(pNciContext);
     PH_LOG_NCI_FUNC_ENTRY();
 
-    if(pPollConfig->PollNfcAActive)
+    /*Note: ListenNfcFActive and PollNfcFActive exist only in NCI1.x specification.*/
+
+    if(pPollConfig->PollNfcAActive ||
+        (pPollConfig->PollNfcFActive && bNci2x))
     {
         pNciContext->NciDiscContext.pDiscPayload[bIndex++] =
         (uint8_t)phNciNfc_NFCA_Active_Poll;
@@ -1117,7 +1122,7 @@ NFCSTATUS phNciNfc_UpdateDiscConfigParams(void *pNciHandle,
     }
     /* Check whether Polling loop to be enabled for NFC-F Technology */
 
-    if(pPollConfig->PollNfcFActive)
+    if(pPollConfig->PollNfcFActive && bNci1x)
     {
         pNciContext->NciDiscContext.pDiscPayload[bIndex++] =
         (uint8_t)phNciNfc_NFCF_Active_Poll;
@@ -1188,7 +1193,8 @@ NFCSTATUS phNciNfc_UpdateDiscConfigParams(void *pNciHandle,
                 (uint8_t)PHNCINFC_LISTEN_DISCFREQ;
         }
 
-        if(1 == pPollConfig->ListenNfcAActive)
+        if(1 == pPollConfig->ListenNfcAActive ||
+            (1 == pPollConfig->ListenNfcFActive && bNci2x))
         {
             /* Configure for Listen mode in active technology */
             pNciContext->NciDiscContext.pDiscPayload[bIndex++] =
@@ -1213,7 +1219,7 @@ NFCSTATUS phNciNfc_UpdateDiscConfigParams(void *pNciHandle,
             pNciContext->NciDiscContext.pDiscPayload[bIndex++] =
                 (uint8_t)PHNCINFC_LISTEN_DISCFREQ;
         }
-        if(1 == pPollConfig->ListenNfcFActive)
+        if(1 == pPollConfig->ListenNfcFActive && bNci1x)
         {
             /* Configure for Listen mode in active technology */
             pNciContext->NciDiscContext.pDiscPayload[bIndex++] =

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -113,6 +113,10 @@ static NFCSTATUS phNciNfc_ProcessInitRsp(void *pContext, NFCSTATUS Status)
         {
             wStatus = phNciNfc_ProcessInitRspNci2x(pContext, Status);
         }
+        else
+        {
+            wStatus = NFCSTATUS_INVALID_PARAMETER;
+        }
     }
     PH_LOG_NCI_FUNC_EXIT();
     return wStatus;

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -60,6 +60,18 @@ phNciNfc_SequenceP_t gphNciNfc_NfccResetSequence[] = {
 Including at least 2 Rf interfaces (in NCI 1.x (17 + 2 = 19) in NCI 2.x (14 + 6 = 20))*/
 #define PH_NCINFC_MIN_CORE_RESET_RSP_LEN          (0x13U)
 
+/** Core Reset Rsp min length NCI 1x
+    NCI1.x Specification Table8: Control Messages to Initialize the NFCC - CORE_INIT_RSP*/
+#define PH_NCINFC_MIN_CORE_INIT_RSP_LEN_1x         (sizeof(uint8_t) +  /* Status */\
+                                                    sizeof(phNciNfc_sCoreNfccFeatures_t) + /* NfccFeatures */\
+                                                    sizeof(uint8_t) +  /* NoOfRfIfSuprt */\
+                                                    sizeof(uint8_t) +  /* MaxLogicalCon */\
+                                                    sizeof(uint16_t) + /* RoutingTableSize */\
+                                                    sizeof(uint8_t) +  /* CntrlPktPayloadLen */\
+                                                    sizeof(uint16_t) + /* MaxSizeLarge */\
+                                                    sizeof(uint8_t) +  /* ManufacturerId */\
+                                                    sizeof(uint32_t)   /* Manufacturer Specific information */)
+
 /** Core Reset notification timeout */
 #define PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS        (30)
 
@@ -261,7 +273,7 @@ static NFCSTATUS phNciNfc_ProcessInitRspNci1x(void *pContext, NFCSTATUS Status)
     if(NULL != pNciContext)
     {
         pInitRsp = &(pNciContext->InitRspParams);
-        if (pNciContext->RspBuffInfo.wLen >= PH_NCINFC_MIN_CORE_RESET_RSP_LEN)
+        if (pNciContext->RspBuffInfo.wLen >= PH_NCINFC_MIN_CORE_INIT_RSP_LEN_1x)
         {
             if (pNciContext->RspBuffInfo.pBuff[Offset++] == PH_NCINFC_STATUS_OK)
             {

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -343,6 +343,10 @@ static NFCSTATUS phNciNfc_ProcessInitRspNci1x(void *pContext, NFCSTATUS Status)
                                 pNciContext->InitRspParams.ManufacturerInfo.Length =
                                                                     PHNCINFC_CORE_MANUF_INFO_LEN_NCI1x;
                             }
+                            else
+                            {
+                                wStatus = NFCSTATUS_FAILED;
+                            }
                         }
                         else if (pNciContext->InitRspParams.ManufacturerInfo.Length !=
                                                                     PHNCINFC_CORE_MANUF_INFO_LEN_NCI1x)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -52,9 +52,12 @@ phNciNfc_SequenceP_t gphNciNfc_NfccResetSequence[] = {
 };
 
 /** NCI2.x Core Reset notification min length
-1 byte Reset Trigger + 1 byte configuration + 1 byte NCI Version +
-1 byte Manufacturer ID + 1 byte Manufacturer Specific Information Length (5)*/
-#define PHNFCINFC_CORE_RESET_NTF_MIN_LEN          (5)
+    NCI2x Specification Table 5: Control Messages to Reset the NFCC - CORE_RESET_NTF*/
+#define PHNFCINFC_CORE_RESET_NTF_MIN_LEN          (sizeof(uint8_t) + /* Reset Trigger */\
+                                                   sizeof(uint8_t) + /* Configuration Status */\
+                                                   sizeof(uint8_t) + /* NCI Version */\
+                                                   sizeof(uint8_t) + /* ManufacturerId*/\
+                                                   sizeof(uint8_t)   /* Manufacturer Specific Information Length */)
 
 /** Core Reset Rsp min length NCI 1x
     NCI1.x Specification Table8: Control Messages to Initialize the NFCC - CORE_INIT_RSP*/

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -220,7 +220,7 @@ static NFCSTATUS phNciNfc_ProcessResetRsp(void *pContext, NFCSTATUS Status)
                 pNciContext->ResetInfo.NciVer = pNciContext->RspBuffInfo.pBuff[1];
 
                 if((pNciContext->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <=
-                   (PH_NCINFC_VERSION & PH_NCINFC_VERSION_MAJOR_MASK))
+                   (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
                 {
                     /* Update Reset type */
                     if(pNciContext->RspBuffInfo.pBuff[2] == phNciNfc_ResetType_KeepConfig)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -53,6 +53,10 @@ phNciNfc_SequenceP_t gphNciNfc_NfccResetSequence[] = {
 1 byte Manufacturer ID + 1 byte Manufacturer Specific Information Length (5)*/
 #define PHNFCINFC_CORE_RESET_NTF_MIN_LEN          (5)
 
+/** Core Reset Rsp min length
+Including at least 2 Rf interfaces (in NCI 1.x (17 + 2 = 19) in NCI 2.x (14 + 6 = 20))*/
+#define PH_NCINFC_MIN_CORE_RESET_RSP_LEN          (0x13U)
+
 /** Core Reset notification timeout */
 #define PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS        (30)
 
@@ -93,7 +97,7 @@ static NFCSTATUS phNciNfc_ProcessInitRsp(void *pContext, NFCSTATUS Status)
     if(NULL != pNciContext)
     {
         pInitRsp = &(pNciContext->InitRspParams);
-        if (pNciContext->RspBuffInfo.wLen >= 19)
+        if (pNciContext->RspBuffInfo.wLen >= PH_NCINFC_MIN_CORE_RESET_RSP_LEN)
         {
             if (pNciContext->RspBuffInfo.pBuff[Offset++] == PH_NCINFC_STATUS_OK)
             {

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -12,6 +12,10 @@ static NFCSTATUS phNciNfc_Init(void *pContext);
 static NFCSTATUS phNciNfc_ProcessInitRsp(void *pContext, NFCSTATUS wStatus);
 static NFCSTATUS phNciNfc_CompleteInitSequence(void *pContext, NFCSTATUS wStatus);
 
+static NFCSTATUS phNciNfc_DelayForResetNtfProc(void* pContext, NFCSTATUS wStatus);
+static NFCSTATUS phNciNfc_DelayForResetNtfInit(void* pContext);
+static NFCSTATUS phNciNfc_DelayForResetNtf(void* pContext);
+
 static NFCSTATUS phNciNfc_InitReset(void *pContext);
 static NFCSTATUS phNciNfc_ProcessResetRsp(void *pContext, NFCSTATUS wStatus);
 static NFCSTATUS phNciNfc_SendReset(void *pContext);
@@ -25,7 +29,9 @@ static NFCSTATUS phNciNfc_RegAllNtfs(void* pContext);
 
 /*Global Varibales for Init Sequence Handler*/
 phNciNfc_SequenceP_t gphNciNfc_InitSequence[] = {
+    {&phNciNfc_DelayForResetNtfInit, &phNciNfc_DelayForResetNtfProc},
     {&phNciNfc_InitReset, &phNciNfc_ProcessResetRsp},
+    {&phNciNfc_DelayForResetNtf, &phNciNfc_DelayForResetNtfProc},
     {&phNciNfc_Init, &phNciNfc_ProcessInitRsp},
     {NULL, &phNciNfc_CompleteInitSequence}
 };
@@ -41,6 +47,14 @@ phNciNfc_SequenceP_t gphNciNfc_NfccResetSequence[] = {
     {&phNciNfc_SendReset, &phNciNfc_ProcessResetRsp},
     {NULL, &phNciNfc_CompleteNfccResetSequence}
 };
+
+/** NCI2.x Core Reset notification min length
+1 byte Reset Trigger + 1 byte configuration + 1 byte NCI Version +
+1 byte Manufacturer ID + 1 byte Manufacturer Specific Information Length (5)*/
+#define PHNFCINFC_CORE_RESET_NTF_MIN_LEN          (5)
+
+/** Core Reset notification timeout */
+#define PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS        (30)
 
 static NFCSTATUS phNciNfc_Init(void *pContext)
 {
@@ -169,31 +183,98 @@ static NFCSTATUS phNciNfc_ProcessInitRsp(void *pContext, NFCSTATUS Status)
         {
             wStatus = NFCSTATUS_FAILED;
         }
-
-        if((NFCSTATUS_SUCCESS == wStatus) &&
-            (0 == pNciContext->tInitInfo.bSkipRegisterAllNtfs))
-        {
-            wStatus = phNciNfc_RegAllNtfs(pNciContext);
-            if(NFCSTATUS_SUCCESS == wStatus)
-            {
-                pNciContext->dwNtfTimerId = phOsalNfc_Timer_Create();
-                if(PH_OSALNFC_TIMER_ID_INVALID == pNciContext->dwNtfTimerId)
-                {
-                    PH_LOG_NCI_CRIT_STR("Notification Timer Create failed!!");
-                    wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
-                }
-                else
-                {
-                    PH_LOG_NCI_INFO_STR("Notification Timer Created Successfully");
-                }
-            }
-        }
     }
     else
     {
         wStatus = NFCSTATUS_INVALID_PARAMETER;
     }
     PH_LOG_NCI_FUNC_EXIT();
+    return wStatus;
+}
+
+static void phNciNfc_ResetNtfDelayCb(uint32_t dwTimerId, void *pContext)
+{
+    pphNciNfc_Context_t pNciContext = (pphNciNfc_Context_t)pContext;
+    /* Internal event is made failed in order to remain in same state */
+    NFCSTATUS wStatus = NFCSTATUS_SUCCESS;
+    UNUSED(dwTimerId);
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    if (NULL != pNciContext)
+    {
+        (void)phOsalNfc_Timer_Stop(pNciContext->dwNtfTimerId);
+        (void)phOsalNfc_Timer_Delete(pNciContext->dwNtfTimerId);
+
+        pNciContext->dwNtfTimerId = 0;
+
+        (void)phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return;
+}
+
+static NFCSTATUS phNciNfc_DelayForResetNtfProc(void* pContext, NFCSTATUS status)
+{
+    UNUSED(status);
+    UNUSED(pContext);
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return NFCSTATUS_SUCCESS;
+}
+
+NFCSTATUS phNciNfc_DelayForResetNtfInit(void* pContext)
+{
+    NFCSTATUS wStatus = NFCSTATUS_SUCCESS;
+    pphNciNfc_Context_t pNciContext = (pphNciNfc_Context_t)pContext;
+
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+
+    if (0 == pNciContext->tInitInfo.bSkipRegisterAllNtfs)
+    {
+        wStatus = phNciNfc_RegAllNtfs(pNciContext);
+    }
+
+    if (wStatus == NFCSTATUS_SUCCESS)
+    {
+        wStatus = phNciNfc_DelayForResetNtf(pContext);
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return wStatus;
+}
+
+NFCSTATUS phNciNfc_DelayForResetNtf(void* pContext)
+{
+    NFCSTATUS wStatus = NFCSTATUS_SUCCESS;
+    pphNciNfc_Context_t pNciContext = (pphNciNfc_Context_t)pContext;
+
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    if (NULL != pNciContext)
+    {
+        PH_LOG_LIBNFC_CRIT_U32MSG("Delay to receive Core Reset ntf", PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS);
+
+        pNciContext->dwNtfTimerId = phOsalNfc_Timer_Create();
+        if (PH_OSALNFC_TIMER_ID_INVALID != pNciContext->dwNtfTimerId)
+        {
+            wStatus = phOsalNfc_Timer_Start(pNciContext->dwNtfTimerId,
+                                            PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS,
+                                            &phNciNfc_ResetNtfDelayCb,
+                                            (void *)pNciContext);
+            if (NFCSTATUS_SUCCESS == wStatus)
+            {
+                wStatus = NFCSTATUS_PENDING;
+            }
+            else
+            {
+                (void)phOsalNfc_Timer_Delete(pNciContext->dwNtfTimerId);
+                pNciContext->dwNtfTimerId = 0;
+                wStatus = NFCSTATUS_FAILED;
+            }
+        }
+    }
+    else
+    {
+        wStatus = NFCSTATUS_INVALID_STATE;
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
     return wStatus;
 }
 
@@ -235,36 +316,66 @@ static NFCSTATUS phNciNfc_ProcessResetRsp(void *pContext, NFCSTATUS Status)
     PH_LOG_NCI_FUNC_ENTRY();
     if(NULL != pNciContext)
     {
-        if((NFCSTATUS_RESPONSE_TIMEOUT != Status) && (pNciContext->RspBuffInfo.wLen == 3))
+        if(NFCSTATUS_RESPONSE_TIMEOUT != Status)
         {
-            /*Check Status Byte*/
-            if (pNciContext->RspBuffInfo.pBuff[0] == PH_NCINFC_STATUS_OK)
+            if (pNciContext->RspBuffInfo.wLen == PHNCINFC_CORE_RESET_RSP_LEN_NCI1x)
             {
-                /* Nfcc supported Nci version */
-                pNciContext->ResetInfo.NciVer = pNciContext->RspBuffInfo.pBuff[1];
-
-                if(PH_NCINFC_VERSION_IS_1x(pNciContext))
+                /*Check Status Byte*/
+                if (pNciContext->RspBuffInfo.pBuff[0] == PH_NCINFC_STATUS_OK)
                 {
-                    /* Update Reset type */
-                    if(pNciContext->RspBuffInfo.pBuff[2] == phNciNfc_ResetType_KeepConfig)
+                    /* Nfcc supported Nci version */
+                    pNciContext->ResetInfo.NciVer = pNciContext->RspBuffInfo.pBuff[1];
+
+                    if(PH_NCINFC_VERSION_IS_1x(pNciContext))
                     {
-                        PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_KeepConfig'");
-                        pNciContext->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_KeepConfig;
-                    }else
-                    {
-                        PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_ResetConfig'");
-                        pNciContext->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_ResetConfig;
+                        /* Update Reset type */
+                        if (pNciContext->RspBuffInfo.pBuff[2] == phNciNfc_ResetType_KeepConfig)
+                        {
+                            PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_KeepConfig'");
+                            pNciContext->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_KeepConfig;
+                        }
+                        else
+                        {
+                            PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_ResetConfig'");
+                            pNciContext->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_ResetConfig;
+                        }
+
+                        wStatus = NFCSTATUS_SUCCESS;
                     }
-
-                    wStatus = NFCSTATUS_SUCCESS;
-                }else
+                    else
+                    {
+                        PH_LOG_NCI_INFO_STR("Unsupported NCI version 0x%02x", pNciContext->ResetInfo.NciVer);
+                        wStatus = NFCSTATUS_FAILED;
+                    }
+                }
+                else
                 {
-                    PH_LOG_NCI_INFO_STR("Unsupported NCI version 0x%02x", pNciContext->ResetInfo.NciVer);
                     wStatus = NFCSTATUS_FAILED;
                 }
-            }else
+            }
+            else if (pNciContext->RspBuffInfo.wLen == PHNCINFC_CORE_RESET_RSP_LEN_NCI2x)
             {
-                wStatus = NFCSTATUS_FAILED;
+                /*Check Status Byte*/
+                if (pNciContext->RspBuffInfo.pBuff[0] == PH_NCINFC_STATUS_OK)
+                {
+                    if (PH_NCINFC_VERSION_IS_2x(pNciContext))
+                    {
+                        wStatus = NFCSTATUS_SUCCESS;
+                    }
+                    else
+                    {
+                        PH_LOG_NCI_INFO_STR("Unsupported NCI version 0x%02x", pNciContext->ResetInfo.NciVer);
+                        wStatus = NFCSTATUS_FAILED;
+                    }
+                }
+                else
+                {
+                    wStatus = NFCSTATUS_FAILED;
+                }
+            }
+            else
+            {
+                wStatus = NFCSTATUS_INVALID_PARAMETER;
             }
         }else
         {
@@ -369,6 +480,8 @@ phNciNfc_ResetNtfCb(void*     pContext,
 {
     pphNciNfc_Context_t pNciCtx = (pphNciNfc_Context_t )pContext;
     pphNciNfc_TransactInfo_t pTransInfo = pInfo;
+    uint8_t wDataLen;
+    uint8_t *pBuff;
     NFCSTATUS wStatus;
 
     wStatus  = status;
@@ -379,14 +492,102 @@ phNciNfc_ResetNtfCb(void*     pContext,
         /* Reset notification received, take necessary action */
         PH_LOG_NCI_INFO_STR("Received RESET notification from NFCC");
 
-        /* Reset Sender statemachine */
-        (void )phNciNfc_CoreResetSenderStateMachine(&pNciCtx->NciCoreContext);
-        (void )phTmlNfc_WriteAbort(pNciCtx->NciCoreContext.pHwRef);
-
-        if(NULL != pNciCtx->tRegListInfo.pResetNtfCb)
+        if (pNciCtx->dwNtfTimerId != 0)
         {
-            pNciCtx->tRegListInfo.pResetNtfCb(pNciCtx->tRegListInfo.ResetNtfCtxt,
-                        eNciNfc_NciResetNtf,NULL,NFCSTATUS_SUCCESS);
+            (void)phOsalNfc_Timer_Stop(pNciCtx->dwNtfTimerId);
+            (void)phOsalNfc_Timer_Delete(pNciCtx->dwNtfTimerId);
+
+            pNciCtx->dwNtfTimerId = 0;
+
+            if (pTransInfo->wLength >= PHNFCINFC_CORE_RESET_NTF_MIN_LEN)
+            {
+                /* Nfcc supported Nci version */
+                pNciCtx->ResetInfo.NciVer = pTransInfo->pbuffer[2];
+                if (PH_NCINFC_VERSION_IS_2x(pNciCtx))
+                {
+                    /* Update Reset type */
+                    if (pTransInfo->pbuffer[1] == phNciNfc_ResetType_KeepConfig)
+                    {
+                        PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_KeepConfig'");
+                        pNciCtx->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_KeepConfig;
+                    }
+                    else
+                    {
+                        PH_LOG_NCI_INFO_STR("Nfcc reseted to 'phNciNfc_ResetType_ResetConfig'");
+                        pNciCtx->ResetInfo.ResetTypeRsp = phNciNfc_ResetType_ResetConfig;
+                    }
+
+                    /*Manufacturer ID*/
+                    pNciCtx->InitRspParams.ManufacturerId = pTransInfo->pbuffer[3];
+                    if (pNciCtx->InitRspParams.ManufacturerId != 0x00)
+                    {
+                        wDataLen = pTransInfo->pbuffer[4];
+                        if (wDataLen == pTransInfo->wLength - PHNFCINFC_CORE_RESET_NTF_MIN_LEN)
+                        {
+                            pBuff = pNciCtx->InitRspParams.ManufacturerInfo.Buffer;
+                            if (pBuff == NULL)
+                            {
+                                pBuff = (uint8_t *)phOsalNfc_GetMemory(wDataLen);
+                                if (pBuff != NULL)
+                                {
+                                    pNciCtx->InitRspParams.ManufacturerInfo.Buffer = pBuff;
+                                    pNciCtx->InitRspParams.ManufacturerInfo.Length = wDataLen;
+                                }
+                                else
+                                {
+                                    wStatus = NFCSTATUS_FAILED;
+                                }
+                            }
+
+                            if (wStatus == NFCSTATUS_SUCCESS &&
+                                pNciCtx->InitRspParams.ManufacturerInfo.Length == wDataLen)
+                            {
+                                if (NULL == memcpy(pBuff,
+                                                   &pTransInfo->pbuffer[PHNFCINFC_CORE_RESET_NTF_MIN_LEN],
+                                                   wDataLen))
+                                {
+                                    wStatus = NFCSTATUS_FAILED;
+                                }
+                                else
+                                {
+                                    /*Reset Trigger*/
+                                    if (pTransInfo->pbuffer[0] == 0) /*If error is unrecoverable*/
+                                        wStatus = NFCSTATUS_FAILED;
+                                    else
+                                        wStatus = NFCSTATUS_SUCCESS;
+                                }
+                            }
+                            else
+                            {
+                                wStatus = NFCSTATUS_FAILED;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    PH_LOG_NCI_INFO_STR("Unsupported NCI version 0x%02x", pNciCtx->ResetInfo.NciVer);
+                    wStatus = NFCSTATUS_FAILED;
+                }
+            }
+            else
+            {
+                wStatus = NFCSTATUS_INVALID_PARAMETER;
+            }
+
+            wStatus = phNciNfc_GenericSequence(pNciCtx, pInfo, status);
+        }
+        else
+        {
+            /* Reset Sender statemachine */
+            (void)phNciNfc_CoreResetSenderStateMachine(&pNciCtx->NciCoreContext);
+            (void)phTmlNfc_WriteAbort(pNciCtx->NciCoreContext.pHwRef);
+
+            if (NULL != pNciCtx->tRegListInfo.pResetNtfCb)
+            {
+                pNciCtx->tRegListInfo.pResetNtfCb(pNciCtx->tRegListInfo.ResetNtfCtxt,
+                        eNciNfc_NciResetNtf, pInfo, NFCSTATUS_SUCCESS);
+            }
         }
     }
     PH_LOG_NCI_FUNC_EXIT();

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -56,10 +56,6 @@ phNciNfc_SequenceP_t gphNciNfc_NfccResetSequence[] = {
 1 byte Manufacturer ID + 1 byte Manufacturer Specific Information Length (5)*/
 #define PHNFCINFC_CORE_RESET_NTF_MIN_LEN          (5)
 
-/** Core Reset Rsp min length
-Including at least 2 Rf interfaces (in NCI 1.x (17 + 2 = 19) in NCI 2.x (14 + 6 = 20))*/
-#define PH_NCINFC_MIN_CORE_RESET_RSP_LEN          (0x13U)
-
 /** Core Reset Rsp min length NCI 1x
     NCI1.x Specification Table8: Control Messages to Initialize the NFCC - CORE_INIT_RSP*/
 #define PH_NCINFC_MIN_CORE_INIT_RSP_LEN_1x         (sizeof(uint8_t) +  /* Status */\
@@ -71,6 +67,18 @@ Including at least 2 Rf interfaces (in NCI 1.x (17 + 2 = 19) in NCI 2.x (14 + 6 
                                                     sizeof(uint16_t) + /* MaxSizeLarge */\
                                                     sizeof(uint8_t) +  /* ManufacturerId */\
                                                     sizeof(uint32_t)   /* Manufacturer Specific information */)
+
+/** Core Reset Rsp min length NCI 2x
+    NCI2.x Specification Table8: Control Messages to Initialize the NFCC - CORE_INIT_RSP*/
+#define PH_NCINFC_MIN_CORE_INIT_RSP_LEN_2x         (sizeof(uint8_t) +  /* Status */\
+                                                    sizeof(phNciNfc_sCoreNfccFeatures_t) + /* NfccFeatures */\
+                                                    sizeof(uint8_t) +  /* MaxLogicalCon */\
+                                                    sizeof(uint16_t) + /* RoutingTableSize */\
+                                                    sizeof(uint8_t) +  /* CntrlPktPayloadLen*/\
+                                                    sizeof(uint8_t) +  /* DataHCIPktPayloadLen */\
+                                                    sizeof(uint8_t) +  /* DataHCINumCredits */\
+                                                    sizeof(uint16_t) + /* MaxNFCVFrameSize */\
+                                                    sizeof(uint8_t)    /* NoOfRfIfSuprt */)
 
 /** Core Reset notification timeout */
 #define PHNCINFC_CORE_RESET_NTF_TIMEOUT_MS        (30)
@@ -151,7 +159,7 @@ static NFCSTATUS phNciNfc_ProcessInitRspNci2x(void *pContext, NFCSTATUS Status)
     if (NULL != pNciContext)
     {
         pInitRsp = &(pNciContext->InitRspParams);
-        if (pNciContext->RspBuffInfo.wLen >= PH_NCINFC_MIN_CORE_RESET_RSP_LEN)
+        if (pNciContext->RspBuffInfo.wLen >= PH_NCINFC_MIN_CORE_INIT_RSP_LEN_2x)
         {
             if (pNciContext->RspBuffInfo.pBuff[Offset++] == PH_NCINFC_STATUS_OK)
             {

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -296,7 +296,11 @@ static NFCSTATUS phNciNfc_ProcessInitRspNci1x(void *pContext, NFCSTATUS Status)
                 /*number of supported RF interfaces*/
                 pInitRsp->NoOfRfIfSuprt = pNciContext->RspBuffInfo.pBuff[Offset++];
 
-                if(pInitRsp->NoOfRfIfSuprt <= PH_NCINFC_CORE_MAX_SUP_RF_INTFS)
+                /* Check RspBuffInfo len is egal to the core reset response min length +
+                   No Of Rf IfSuprt */
+                if(pInitRsp->NoOfRfIfSuprt <= PH_NCINFC_CORE_MAX_SUP_RF_INTFS &&
+                   pNciContext->RspBuffInfo.wLen == pInitRsp->NoOfRfIfSuprt +
+                                                    PH_NCINFC_MIN_CORE_INIT_RSP_LEN_1x)
                 {
                     /*Supported RF Interfaces */
                     phOsalNfc_MemCopy(pInitRsp->RfInterfaces, &(pNciContext->RspBuffInfo.pBuff[Offset]),

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -440,7 +440,11 @@ static void phNciNfc_ResetNtfDelayCb(uint32_t dwTimerId, void *pContext)
 
         pNciContext->dwNtfTimerId = 0;
 
-        (void)phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+        wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+        if (wStatus != NFCSTATUS_SUCCESS)
+        {
+            PH_LOG_NCI_INFO_STR("phNciNfc_GenericSequence returned error %d", wStatus);
+        }
     }
     PH_LOG_LIBNFC_FUNC_EXIT();
     return;

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -212,6 +212,7 @@ static NFCSTATUS phNciNfc_ProcessInitRspNci2x(void *pContext, NFCSTATUS Status)
                                      wStatus == NFCSTATUS_SUCCESS; bCount++)
                     {
                         /* Parse the buffer */
+                        /* The function will return an error status in case of invalid TLV format */
                         wStatus = phNciNfc_TlvUtilsGetNxtTlv(&tTlvInfo, &bType, &bLen, &pValue);
                         Offset += bLen + 2;
                     }

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -219,8 +219,7 @@ static NFCSTATUS phNciNfc_ProcessResetRsp(void *pContext, NFCSTATUS Status)
                 /* Nfcc supported Nci version */
                 pNciContext->ResetInfo.NciVer = pNciContext->RspBuffInfo.pBuff[1];
 
-                if((pNciContext->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <=
-                   (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
+                if(PH_NCINFC_VERSION_IS_1x(pNciContext))
                 {
                     /* Update Reset type */
                     if(pNciContext->RspBuffInfo.pBuff[2] == phNciNfc_ResetType_KeepConfig)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_ListenNfcDep.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_ListenNfcDep.c
@@ -19,6 +19,8 @@ phNciNfc_NfcDepLstnRdrAInit(
     uint8_t                     *pRfNtfBuff = NULL;
     uint8_t                     RfTechSpecParamsLen = 0;
     uint8_t                     ActvnParamsLen = 0;
+    uint8_t                     AtrLen = 0;
+    uint8_t                     bCount = 7;
 
     PH_LOG_NCI_FUNC_ENTRY();
     if((0 != (wLen)) && (NULL != pBuff) && (NULL != pRemDevInf))
@@ -27,7 +29,7 @@ phNciNfc_NfcDepLstnRdrAInit(
         RfTechSpecParamsLen = pBuff[6];
 
         /* Shift the buffer pointer points to first parameter of technology specific parameters */
-        pRfNtfBuff = &pBuff[7];
+        pRfNtfBuff = &pBuff[bCount];
 
         /* The activated remote device is a P2P Initiator */
         (pRemDevInf->RemDevType) = phNciNfc_eNfcIP1_Initiator;
@@ -45,21 +47,52 @@ phNciNfc_NfcDepLstnRdrAInit(
                 pRemDevInf->tRemoteDevInfo.NfcIP_Info.Nfcip_Active = 0; /* Passive communciation */
             break;
         }
-        /* Obtain the length of Activation parameters from pBuff */
-        ActvnParamsLen = pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN];
 
-        /* Holds ATR_RES if remote device is a P2P target and ATR_REQ if remote device is a
-           P2P initiator */
+        bCount += RfTechSpecParamsLen + PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN;
+        /* Obtain the length of Activation parameters from pBuff */
+        ActvnParamsLen = pBuff[bCount];
         if(0 != ActvnParamsLen)
         {
-            pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = (ActvnParamsLen-1);
-            pRfNtfBuff = &(pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN+2]);
-            phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,0,
+            bCount++;
+            AtrLen = pBuff[bCount];
+
+            /* Holds ATR_RES if remote device is a P2P target and ATR_REQ if remote device is a
+               P2P initiator */
+            /* The relevant ATR Length is present in the first activation parameter.
+               In the case of NCI 2.0, we ignore the Data Exchange Length Reduction parameter for now */
+            if (0 != AtrLen)
+            {
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = AtrLen;
+                bCount++;
+                pRfNtfBuff = &(pBuff[bCount]);
+                phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo, 0,
+                                    PH_NCINFCTYPES_ATR_MAX_LEN);
+                if (pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)
+                {
+                    phOsalNfc_MemCopy(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,
+                                pRfNtfBuff, pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length);
+                }
+                else
+                {
+                    pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = 0;
+                    PH_LOG_NCI_CRIT_STR("Invalid ATR_INFO length");
+                    status = NFCSTATUS_FAILED;
+                }
+            }
+        }
+
+        if(0 != RfTechSpecParamsLen)
+        {
+            pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = pRfNtfBuff[0];
+            phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo, 0,
                                 PH_NCINFCTYPES_ATR_MAX_LEN);
             if(pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)
             {
+                /* Specific Parameters for NFC-ACM Listen Mode have the following format:
+                    - ATR_RES Response Length: 1 byte
+                    - ATR_RES Response: n bytes*/
                 phOsalNfc_MemCopy(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,
-                            pRfNtfBuff,pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length);
+                            pRfNtfBuff + 1, pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length);
             }
             else
             {
@@ -68,6 +101,20 @@ phNciNfc_NfcDepLstnRdrAInit(
                 status = NFCSTATUS_FAILED;
             }
         }
+
+        /* In NCI1.0 NFC-DEP params are stored in Activation Parameters
+           In NCI2.0 NFC-DEP params are stored in:
+           - RF Technology Specific Parameters in case of Active P2P
+           - Activation Parameters in case of Passive P2P
+           If using Active Communication Mode the RF_INTF_ACTIVATED_INTF SHALL NOT include any
+           Activation Parameters. */
+        if(0 != ActvnParamsLen && pRemDevInf->tRemoteDevInfo.NfcIP_Info.Nfcip_Active == 1 &&
+           PH_NCINFC_VERSION_IS_2x(PHNCINFC_GETNCICONTEXT()))
+        {
+            status = PHNFCSTVAL(CID_NFC_NCI, NFCSTATUS_INVALID_PARAMETER);
+            PH_LOG_NCI_INFO_STR(" Invalid Params..");
+        }
+
         /* The Activated device is a P2P Initiator. The P2P 'Send' and 'Receive' functions shall be active.
            The P2P Target (i.e., us) is expected to receive data from remote P2P initiator and expected
            to send data to Remote P2P target in response */
@@ -92,6 +139,8 @@ phNciNfc_NfcDepLstnRdrFInit(
     uint8_t                     RfTechSpecParamsLen;
     uint8_t                     bNfcId2Len;
     uint8_t                     ActvnParamsLen = 0;
+    uint8_t                     AtrLen = 0;
+    uint8_t                     bCount = 7;
 
     PH_LOG_NCI_FUNC_ENTRY();
     if( (0 != (wLen)) && (NULL != pBuff) && (NULL != pRemDevInf))
@@ -101,7 +150,7 @@ phNciNfc_NfcDepLstnRdrFInit(
 
         /* Obtain the len of RF tech specific parameters from Resp buff */
         RfTechSpecParamsLen = pBuff[6]; /*TODO: Check should added for this*/
-        pRfNtfBuff = &pBuff[7];
+        pRfNtfBuff = &pBuff[bCount];
 
         bNfcId2Len = *(pRfNtfBuff);
 
@@ -141,13 +190,21 @@ phNciNfc_NfcDepLstnRdrFInit(
                     pRemDevInf->tRemoteDevInfo.NfcIP_Info.Nfcip_Active = 0; /* Passive communciation */
                 break;
             }
-            /* Obtain the length of Activation parameters from pBuff */
-            ActvnParamsLen = pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN];
 
-            if(0 != ActvnParamsLen)
+            bCount += RfTechSpecParamsLen + PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN;
+            /* Obtain the length of Activation parameters from pBuff */
+            ActvnParamsLen = pBuff[bCount];
+
+            if (0 != ActvnParamsLen)
             {
-                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = (ActvnParamsLen-1);
-                pRfNtfBuff = &(pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN+2]);
+                bCount++;
+                AtrLen = pBuff[bCount];
+            }
+            if(0 != AtrLen)
+            {
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = AtrLen;
+                bCount++;
+                pRfNtfBuff = &(pBuff[bCount]);
                 phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,0,
                                     PH_NCINFCTYPES_ATR_MAX_LEN);
                 if(pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_PollNfcDep.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_PollNfcDep.c
@@ -16,16 +16,21 @@ phNciNfc_NfcDepPollRdrAInit(
 {
     NFCSTATUS                   status = NFCSTATUS_SUCCESS;
     uint8_t                     *pRfNtfBuff = NULL;
+    uint8_t                     RfTech;
     uint8_t                     RfTechSpecParamsLen = 0;
     uint8_t                     ActvnParamsLen = 0;
+    uint8_t                     AtrLen = 0;
     uint8_t                     bSelResRespLen = 0;
     uint8_t                     bUidLength = 0;
     uint8_t                     bSelRespVal = 0;
+    uint8_t                     bCount = 7;
 
     PH_LOG_NCI_FUNC_ENTRY();
 
     if((0 != (wLen)) && (NULL != pBuff) && (NULL != pRemDevInf))
     {
+        RfTech = pBuff[3];
+
         /* Length of technology specific parameters */
         RfTechSpecParamsLen = pBuff[6];
 
@@ -37,57 +42,80 @@ phNciNfc_NfcDepPollRdrAInit(
         if(0 != RfTechSpecParamsLen)
         {
             /* Point the buffer to the first parameter of technology specific parameters */
-            pRfNtfBuff = &pBuff[7];
+            pRfNtfBuff = &pBuff[bCount];
 
-            /* Get technology specific parameters incase of Nfc-A poll mode */
-            /* Length of NFCID1 */
-            bUidLength = *(pRfNtfBuff+2);
-            /* Length of SEL_RES response */
-            bSelResRespLen = *(pRfNtfBuff + 3 + bUidLength);
-            if(0 != bSelResRespLen)
+            if(RfTech == phNciNfc_NFCA_Poll)
             {
-                /* Length of SEL_RES should always be '1' as per Nci spec ver 25 */
-                if(1 == bSelResRespLen)
+                /* Get technology specific parameters incase of Nfc-A poll mode */
+                /* Length of NFCID1 */
+                bUidLength = *(pRfNtfBuff + 2);
+                /* Length of SEL_RES response */
+                bSelResRespLen = *(pRfNtfBuff + 3 + bUidLength);
+                if(0 != bSelResRespLen)
                 {
-                    /* Length of SEL_RES shall be '0' incase of Nfc Forum Type 1 Tag */
-                    bSelRespVal = *(pRfNtfBuff + 3 + bUidLength + 1);
+                    /* Length of SEL_RES should always be '1' as per Nci spec ver 25 */
+                    if(1 == bSelResRespLen)
+                    {
+                        /* Length of SEL_RES shall be '0' incase of Nfc Forum Type 1 Tag */
+                        bSelRespVal = *(pRfNtfBuff + 3 + bUidLength + 1);
+                    }
+                    else
+                    {
+                        PH_LOG_NCI_CRIT_STR("Invalid SEL_RES length");
+                        status = NFCSTATUS_FAILED;
+                    }
+                }
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.SelRes = bSelRespVal;
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.SelResLen = bSelResRespLen;
+
+                phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensRes, 0,
+                                    PH_NCINFCTYPES_SENS_RES_LEN);
+                /* Sense Response incase of Poll Nfc-A is of 2 bytes (incase of Poll Nfc-F, its 16 or 18 bytes) */
+                phOsalNfc_MemCopy(pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensRes, pRfNtfBuff, 2);
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensResLength = 2;
+
+                /* NFCID3 shall is always 10 bytes */
+                if(0 == bUidLength)
+                {
+                    PH_LOG_NCI_CRIT_STR("NFCID3 does not exist");
+                }
+                else if((PH_NCINFCTYPES_NFCID1_4BYTES == bUidLength) ||
+                        (PH_NCINFCTYPES_NFCID1_7BYTES == bUidLength) ||
+                        (PH_NCINFCTYPES_MAX_NFCID1_SIZE == bUidLength))
+                {
+                    pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID_Length = bUidLength;
+                    phOsalNfc_SetMemory((pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID), 0,
+                                PH_NCINFCTYPES_MAX_NFCID3_SIZE);
+                    phOsalNfc_MemCopy(&(pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID),
+                                (pRfNtfBuff + 3), bUidLength);
                 }
                 else
                 {
-                    PH_LOG_NCI_CRIT_STR("Invalid SEL_RES length");
+                    PH_LOG_NCI_CRIT_STR("Invalid NFCID3 length");
                     status = NFCSTATUS_FAILED;
                 }
             }
-            pRemDevInf->tRemoteDevInfo.NfcIP_Info.SelRes = bSelRespVal;
-            pRemDevInf->tRemoteDevInfo.NfcIP_Info.SelResLen = bSelResRespLen;
-
-            phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensRes,0,
-                                PH_NCINFCTYPES_SENS_RES_LEN);
-            /* Sense Response incase of Poll Nfc-A is of 2 bytes (incase of Poll Nfc-F, its 16 or 18 bytes) */
-            phOsalNfc_MemCopy(pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensRes,pRfNtfBuff,2);
-            pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensResLength = 2;
-
-            /* NFCID3 shall is always 10 bytes */
-            if(0 == bUidLength)
-            {
-                PH_LOG_NCI_CRIT_STR("NFCID3 does not exist");
-            }
-            else if((PH_NCINFCTYPES_NFCID1_4BYTES == bUidLength) ||
-                    (PH_NCINFCTYPES_NFCID1_7BYTES == bUidLength) ||
-                    (PH_NCINFCTYPES_MAX_NFCID1_SIZE == bUidLength))
-            {
-                pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID_Length = bUidLength;
-                phOsalNfc_SetMemory((pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID),0,
-                            PH_NCINFCTYPES_MAX_NFCID3_SIZE);
-                phOsalNfc_MemCopy(&(pRemDevInf->tRemoteDevInfo.NfcIP_Info.NFCID),
-                            (pRfNtfBuff+3),bUidLength);
-            }
             else
             {
-                PH_LOG_NCI_CRIT_STR("Invalid NFCID3 length");
-                status = NFCSTATUS_FAILED;
-            }
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = pRfNtfBuff[0];
+                phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo, 0,
+                            PH_NCINFCTYPES_ATR_MAX_LEN);
 
+                if(pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)
+                {
+                    /* Specific Parameters for NFC-ACM Poll Mode have the following format:
+                       - ATR_REQ Response Length: 1 byte
+                       - ATR_REQ Response: n bytes*/
+                    phOsalNfc_MemCopy(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,
+                        pRfNtfBuff + 1, pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length);
+                }
+                else
+                {
+                    pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = 0;
+                    PH_LOG_NCI_CRIT_STR("Invalid ATR_INFO length");
+                    status = NFCSTATUS_FAILED;
+                }
+            }
         }
 
         if(NFCSTATUS_SUCCESS == status)
@@ -110,15 +138,23 @@ phNciNfc_NfcDepPollRdrAInit(
             /* Update gpphNciNfc_RdrDataXchgSequence with the appropriate functions to be called
                    by sequence handler on invocation during data exchange */
             /* Obtain the length of Activation parameters from pBuff */
-            ActvnParamsLen = pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN];
+            bCount += RfTechSpecParamsLen + PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN;
+            ActvnParamsLen = pBuff[bCount];
+            if (0 != ActvnParamsLen)
+            {
+                bCount++;
+                AtrLen = pBuff[bCount];
+            }
 
             /* Holds ATR_RES if remote device is a P2P target and ATR_REQ if remote device is a
                P2P initiator */
-
-            if(0 != ActvnParamsLen)
+            /* The relevant ATR Length is present in the first activation parameter.
+               In the case of NCI 2.0, we ignore the Data Exchange Length Reduction parameter for now */
+            if(0 != AtrLen)
             {
-                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = (ActvnParamsLen-1);
-                pRfNtfBuff = &(pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN+2]);
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = AtrLen;
+                bCount++;
+                pRfNtfBuff = &(pBuff[bCount]);
                 phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,0,
                                     PH_NCINFCTYPES_ATR_MAX_LEN);
                 if(pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)
@@ -132,6 +168,20 @@ phNciNfc_NfcDepPollRdrAInit(
                     PH_LOG_NCI_CRIT_STR("Invalid ATR_INFO length");
                     status = NFCSTATUS_FAILED;
                 }
+            }
+
+            /* In NCI1.0 NFC-DEP params are stored in Activation Parameters
+            In NCI2.0 NFC-DEP params are stored in:
+            - RF Technology Specific Parameters in case of Active P2P
+            - Activation Parameters in case of Passive P2P
+            If using Active Communication Mode the RF_INTF_ACTIVATED_INTF SHALL NOT include any
+            Activation Parameters.
+            */
+            if(0 != ActvnParamsLen && pRemDevInf->tRemoteDevInfo.NfcIP_Info.Nfcip_Active == 1 &&
+               PH_NCINFC_VERSION_IS_2x(PHNCINFC_GETNCICONTEXT()))
+            {
+                status = PHNFCSTVAL(CID_NFC_NCI, NFCSTATUS_INVALID_PARAMETER);
+                PH_LOG_NCI_INFO_STR(" Invalid Params..");
             }
 
             /* If Activated device is P2P Target. Only 'Transreceive' function shall be active
@@ -165,6 +215,8 @@ phNciNfc_NfcDepPollRdrFInit(
     uint8_t   RfTechSpecParamsLen;
     uint8_t   SensFResRespLen;
     uint8_t   ActvnParamsLen = 0;
+    uint8_t   AtrLen = 0;
+    uint8_t   bCount = 7;
 
     PH_LOG_NCI_FUNC_ENTRY();
     if( (0 != (wLen)) && (NULL != pBuff) && (NULL != pRemDevInf))
@@ -174,7 +226,7 @@ phNciNfc_NfcDepPollRdrFInit(
 
         /* Obtain the len of RF tech specific parameters from Resp buff */
         RfTechSpecParamsLen = pBuff[6];
-        pRfNtfBuff = &pBuff[7];
+        pRfNtfBuff = &pBuff[bCount];
 
         /* Clear the information */
         pRemDevInf->tRemoteDevInfo.NfcIP_Info.SensResLength = 0;
@@ -231,12 +283,22 @@ phNciNfc_NfcDepPollRdrFInit(
             /* Target speed (Target to initiator speed) */
             pRemDevInf->tRemoteDevInfo.NfcIP_Info.Nfcip_Datarate = (phNciNfc_BitRates_t)pRemDevInf->bTransBitRate;
             /* Obtain the length of Activation parameters from pBuff */
-            ActvnParamsLen = pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN];
+            bCount += RfTechSpecParamsLen + PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN;
+            ActvnParamsLen = pBuff[bCount];
 
-            if(0 != ActvnParamsLen)
+            /* The relevant ATR Length is present in the first activation parameter.
+               In the case of NCI 2.0, we ignore the Data Exchange Length Reduction parameter for now */
+            if (0 != ActvnParamsLen)
             {
-                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = (ActvnParamsLen-1);
-                pRfNtfBuff = &(pBuff[7+RfTechSpecParamsLen+PH_NCINFCTYPES_DATA_XCHG_PARAMS_LEN+2]);
+                bCount++;
+                AtrLen = pBuff[bCount];
+            }
+
+            if(0 != AtrLen)
+            {
+                pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length = AtrLen;
+                bCount++;
+                pRfNtfBuff = &(pBuff[bCount]);
                 phOsalNfc_SetMemory(pRemDevInf->tRemoteDevInfo.NfcIP_Info.aAtrInfo,0,
                                     PH_NCINFCTYPES_ATR_MAX_LEN);
                 if(pRemDevInf->tRemoteDevInfo.NfcIP_Info.bATRInfo_Length <= PH_NCINFCTYPES_ATR_MAX_LEN)

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_RFReaderA.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_RFReaderA.c
@@ -135,6 +135,7 @@ phNciNfc_RdrAInit(
                     PH_LOG_NCI_INFO_STR(" Invalid UID Length received");
                 }
             }
+            break;
             case phNciNfc_eKovio_PICC:
             {
                 // The tag ID is all we get

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
@@ -14,6 +14,25 @@
 #define PHNCINFC_GETNCICORECONTEXT() gpphNciNfc_CoreContext
 
 /**
+* \ingroup grp_nci_nfc
+* \brief The supported NCI version of the specification
+*/
+#define PH_NCINFC_VERSION_MAJOR_MASK                (0xF0)
+#define PH_NCINFC_VERSION_MINOR_MASK                (0x0F)
+
+#define PH_NCINFC_VERSION_MAJOR_1x                  (0x01)
+#define PH_NCINFC_VERSION_MINOR_1x                  (0x00)
+#define PH_NCINFC_VERSION_MAJOR_2x                  (0x02)
+#define PH_NCINFC_VERSION_MINOR_2x                  (0x00)
+
+#define PH_NCINFC_VERSION_1x                        ((PH_NCINFC_VERSION_MAJOR_1x << 4) | PH_NCINFC_VERSION_MINOR_1x)
+#define PH_NCINFC_VERSION_IS_1x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) <= \
+                                                     (PH_NCINFC_VERSION_1x & PH_NCINFC_VERSION_MAJOR_MASK))
+#define PH_NCINFC_VERSION_2x                        ((PH_NCINFC_VERSION_MAJOR_2x << 4) | PH_NCINFC_VERSION_MINOR_2x)
+#define PH_NCINFC_VERSION_IS_2x(x)                  ((x->ResetInfo.NciVer & PH_NCINFC_VERSION_MAJOR_MASK) == \
+                                                     (PH_NCINFC_VERSION_2x & PH_NCINFC_VERSION_MAJOR_MASK))
+
+/**
  * \ingroup grp_nci_nfc_core
  *
  * \brief Internal Callback for handling the sequence/state needs.
@@ -680,6 +699,14 @@ typedef struct phNciNfc_sInitRspParams
     uint16_t RoutingTableSize;                          /**<Maximum Routing table size*/
     uint8_t CntrlPktPayloadLen;                         /**<Maximum payload length of a NCI control Packet Valid range
                                                             32 to 255*/
+    uint8_t DataHCIPktPayloadLen;                       /**<Maximum payload length of a NCI data Packet that the NFCC
+                                                            is able to receive on the static HCI Connection Valid range
+                                                            32 to 255. If not, the value SHALL be 0*/
+    uint8_t DataHCINumCredits;                          /**<Initial Number of Credits for this Connection*/
+    uint16_t MaxNFCVFrameSize;                          /**<Maximum payload length of an NFC-V Standard Frame supported
+                                                            by the NFC Controller for transfer of Commands and reception
+                                                            of Responses, when configured to Poll for NFC-V technology.
+                                                            Value should be at least 64 bytes*/
     uint16_t MaxSizeLarge;                              /**<The maximum size in octets for the sum of the
                                                             sizes of PB_H_INFO and LB_H_INFO_RESP parameter values.*/
     uint8_t ManufacturerId;                             /**<IC Manufacturer ID */

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
@@ -287,6 +287,13 @@ typedef void (*pphNciNfc_ConnCreditsNtf_t)(void* pContext, uint8_t bCredits, NFC
 /**
  * \ingroup grp_nci_nfc_core
  *
+ * \brief Manufacturer Information size in NCI 1.x
+  */
+#define PHNCINFC_CORE_MANUF_INFO_LEN_NCI1x		(4)
+
+/**
+ * \ingroup grp_nci_nfc_core
+ *
  * \brief Invalid connection Id
   */
 
@@ -661,11 +668,9 @@ typedef struct phNciNfc_sInitRspParams
     uint8_t ManufacturerId;                             /**<IC Manufacturer ID */
     struct                                              /**<NFCC manufacturer specific information*/
     {
-        uint8_t Byte0;
-        uint8_t Byte1;
-        uint8_t Byte2;
-        uint8_t Byte3;
-    }ManufacturerInfo;                                  /**< Manufacturer information */
+        uint8_t Length;
+        uint8_t *Buffer;                                /**<Manufacturer information NCI*/
+    }ManufacturerInfo;
 }phNciNfc_sInitRspParams_t, *pphNci_sInitRspParams_t; /**< pointer to #phNci_sInitRspParams_t */
 
 /**

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
@@ -151,6 +151,23 @@ typedef void (*pphNciNfc_ConnCreditsNtf_t)(void* pContext, uint8_t bCredits, NFC
   */
 #define PHNCINFC_CORE_PBF_BIT_OFFSET                (4U)
 
+/**
+  * \ingroup grp_nci_nfc_core
+  *
+  * \brief Core Reset Rsp length in NCI 1.x
+  * 1 byte for status / 1 byte for NCI version / 1 byte for Configuration Status
+  */
+#define PHNCINFC_CORE_RESET_RSP_LEN_NCI1x           (3U)
+
+/**
+  * \ingroup grp_nci_nfc_core
+  *
+  * \brief Core Reset Rsp length in NCI 2.x
+  * 1 byte for status
+  */
+#define PHNCINFC_CORE_RESET_RSP_LEN_NCI2x           (1U)
+
+
 /*-------------------------------------------------------------------------------*/
 /*Sets Header information in Byte format, Byte value to set is passed as n and
   v is the value*/

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_CoreSend.c
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_CoreSend.c
@@ -9,7 +9,6 @@
 #include "phNciNfc_CoreSend.tmh"
 
 #define PHNCINFC_WAITCREDIT_TO_REDUCTION    (50)
-#define PHNCINFC_MIN_WAITCREDIT_TO          (250)
 
 typedef NFCSTATUS (*phNciNfc_CoreSend_t)(phNciNfc_CoreContext_t *pContext);
 

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_DbgDescription.c
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_DbgDescription.c
@@ -316,7 +316,7 @@ void phNciNfc_PrintCoreResetRspDescription(uint8_t *pBuff, uint16_t wLen)
     PH_LOG_NCI_INFO_STR("Configuration Status: %!NCI_RESET_TYPE!", pBuff[2]);
 }
 
-void phNciNfc_PrintCoreInitRspDescription(uint8_t *pBuff, uint16_t wLen)
+void phNciNfc_PrintCoreInitNci1xRspDescription(uint8_t *pBuff, uint16_t wLen)
 {
     uint8_t bCount = 0, bIndex = 0, bStatus, bNumInterfaces;
     uint16_t wMaxRoutingTableSize, wMaxSizeLargeParam;
@@ -387,6 +387,84 @@ void phNciNfc_PrintCoreInitRspDescription(uint8_t *pBuff, uint16_t wLen)
         PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex+4, wLen);
         for (bCount = 0; bCount < 4; bCount++) {
             PH_LOG_NCI_INFO_STR("Manufacturer Specific Info Byte%d: 0x%x", (uint32_t)bCount+1, (uint32_t)pBuff[bIndex++]);
+        }
+    }
+}
+
+void phNciNfc_PrintCoreInitNci2xRspDescription(uint8_t *pBuff, uint16_t wLen)
+{
+    uint8_t bCount = 0, bIndex = 0, bStatus, bNumInterfaces, bExtLen;
+    uint16_t wMaxRoutingTableSize, wMaxNFCVFrameSize;
+    phNciNfc_sCoreNfccFeatures_t tNfccFeatures;
+
+    PHNCINFC_VALIDATE_PACKET_LENGTH(1, wLen);
+    bStatus = pBuff[bIndex++];
+    PH_LOG_NCI_INFO_STR("Status: %!NCI_STATUS!", bStatus);
+
+    if (bStatus == PH_NCINFC_STATUS_OK)
+    {
+        PH_LOG_NCI_INFO_STR("Discovery Configuration Mode:");
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 4, wLen);
+        tNfccFeatures.DiscConfSuprt = pBuff[bIndex++];
+        tNfccFeatures.RoutingType = pBuff[bIndex++];
+        tNfccFeatures.PwrOffState = pBuff[bIndex++];
+        tNfccFeatures.Byte3 = pBuff[bIndex++];
+
+        if (tNfccFeatures.DiscConfSuprt & 0x01) {
+            PH_LOG_NCI_INFO_STR("Discovery Frequency supported");
+        }
+        else {
+            PH_LOG_NCI_INFO_STR("Discovery Frequency value is ignored");
+        }
+
+        if ((tNfccFeatures.DiscConfSuprt & 0x06) == 0x00) {
+            PH_LOG_NCI_INFO_STR("DH is the only entity that configures the NFCC");
+        }
+        else {
+            PH_LOG_NCI_INFO_STR("NFCC can receive configurations from the DH and other NFCEEs");
+        }
+
+        PH_LOG_NCI_INFO_STR("Technology based routing %s", (tNfccFeatures.RoutingType & 0x02) ? "supported" : "not supported");
+        PH_LOG_NCI_INFO_STR("Protocol based routing %s", (tNfccFeatures.RoutingType & 0x04) ? "supported" : "not supported");
+        PH_LOG_NCI_INFO_STR("AID based routing %s", (tNfccFeatures.RoutingType & 0x08) ? "supported" : "not supported");
+        PH_LOG_NCI_INFO_STR("Battery Off state %s", (tNfccFeatures.PwrOffState & 0x01) ? "supported" : "not supported");
+        PH_LOG_NCI_INFO_STR("Switched Off state %s", (tNfccFeatures.PwrOffState & 0x02) ? "supported" : "not supported");
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 1, wLen);
+        PH_LOG_NCI_INFO_X32MSG("Max Logical Connections:", (uint32_t)pBuff[bIndex++]);
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 2, wLen);
+        wMaxRoutingTableSize = ((uint16_t)pBuff[bIndex] + ((uint16_t)pBuff[bIndex + 1] << 8));
+        PH_LOG_NCI_INFO_X32MSG("Max Routing Table Size:", (uint32_t)wMaxRoutingTableSize);
+        bIndex += 2;
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 1, wLen);
+        PH_LOG_NCI_INFO_X32MSG("Max Control Packet Payload Size:", (uint32_t)pBuff[bIndex++]);
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 1, wLen);
+        PH_LOG_NCI_INFO_X32MSG("Max Data Packet Payload Size of the Static HCI Connection:", (uint32_t)pBuff[bIndex++]);
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 1, wLen);
+        PH_LOG_NCI_INFO_X32MSG("Number of Credits of the Static HCI Connection:", (uint32_t)pBuff[bIndex++]);
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 2, wLen);
+        wMaxNFCVFrameSize = ((uint16_t)pBuff[bIndex] + ((uint16_t)pBuff[bIndex + 1] << 8));
+        PH_LOG_NCI_INFO_X32MSG("Max NFC-V RF Frame Size:", (uint32_t)wMaxNFCVFrameSize);
+        bIndex += 2;
+
+        PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 1, wLen);
+        bNumInterfaces = pBuff[bIndex++];
+        PH_LOG_NCI_INFO_X32MSG("Number of Supported RF Interfaces:", (uint32_t)bNumInterfaces);
+
+        for (bCount = 0; bCount < bNumInterfaces; bCount++) {
+            PHNCINFC_VALIDATE_PACKET_LENGTH(bIndex + 2, wLen);
+            PH_LOG_NCI_INFO_STR("RF Interface: %!NCI_RF_INTERFACE!", pBuff[bIndex++]);
+            bExtLen = pBuff[bIndex++];
+            PH_LOG_NCI_INFO_STR("Number of Extensions: %d", bExtLen);
+            PH_LOG_NCI_INFO_HEXDUMP("Extension List: %!HEXDUMP!",
+                WppLogHex((void*)&pBuff[bIndex], (uint16_t)bExtLen));
+            bIndex += bExtLen;
         }
     }
 }
@@ -1019,7 +1097,15 @@ void phNciNfc_PrintPacketDescription(
                     phNciNfc_PrintCoreResetRspDescription(pBuff, wLen);
                     break;
                 case phNciNfc_e_NciCoreInitRspOid:
-                    phNciNfc_PrintCoreInitRspDescription(pBuff, wLen);
+                    switch (NciVer & PH_NCINFC_VERSION_MAJOR_MASK)
+                    {
+                    case PH_NCINFC_VERSION_1x:
+                        phNciNfc_PrintCoreInitNci1xRspDescription(pBuff, wLen);
+                        break;
+                    case PH_NCINFC_VERSION_2x:
+                        phNciNfc_PrintCoreInitNci2xRspDescription(pBuff, wLen);
+                        break;
+                    }
                     break;
                 case phNciNfc_e_NciCoreSetConfigRspOid:
                     phNciNfc_PrintCoreSetConfigRspDescription(pBuff, wLen);

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.c
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.c
@@ -22,12 +22,12 @@ phNciNfc_LogConnMgmtInit()
 
     phOsalNfc_SetMemory(&gphNciNfc_ConnMgmtInt, 0x00, sizeof(phNciNfc_LogConnMgmt_Int_t));
 
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].tConn.bConnId =  CONNTYPE_STATIC;
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].tConn.bMaxDpldSize = 0;
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].tConn.bNumCredits = 0;
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bDestId = UNASSIGNED_DESTID;
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bDestType = phNciNfc_e_UNKNOWN_DEST_TYPE;
-    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bIfActive = FALSE;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].tConn.bConnId =  CONNRFTYPE_STATIC;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].tConn.bMaxDpldSize = 0;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].tConn.bNumCredits = 0;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bDestId = UNASSIGNED_DESTID;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bDestType = phNciNfc_e_UNKNOWN_DEST_TYPE;
+    gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bIfActive = FALSE;
 
     gphNciNfc_ConnMgmtInt.tConnInfo.bOpenConns = 1;
 
@@ -283,12 +283,12 @@ phNciNfc_UpdateConnDestInfo(
         {
             pphNciNfc_RemoteDevInformation_t  pActvDev = (pphNciNfc_RemoteDevInformation_t)pHandle;
 
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bDestId = pActvDev->bRfDiscId;
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bDestType = tDestType;
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].tConn.bMaxDpldSize = pActvDev->bMaxPayLoadSize;
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].tConn.bNumCredits = pActvDev->bInitialCredit;
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].bIfActive = TRUE;
-            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNTYPE_STATIC].pActvDevHandle = pActvDev;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bDestId = pActvDev->bRfDiscId;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bDestType = tDestType;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].tConn.bMaxDpldSize = pActvDev->bMaxPayLoadSize;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].tConn.bNumCredits = pActvDev->bInitialCredit;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].bIfActive = TRUE;
+            gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[CONNRFTYPE_STATIC].pActvDevHandle = pActvDev;
         }
         else
         {
@@ -325,7 +325,7 @@ phNciNfc_GetConnCredits(
             if(bConnId == (gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId) )
             {
                 if((TRUE == (gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive)) ||
-                    (CONNTYPE_STATIC == (gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)))
+                    (CONNRFTYPE_STATIC == (gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)))
                 {
                     *pCredits = (gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bNumCredits);
                     wStatus = NFCSTATUS_SUCCESS;
@@ -368,7 +368,7 @@ NFCSTATUS phNciNfc_RegForConnCredits(
             if(bConnId == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)
             {
                 if((TRUE == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive) ||
-                    (CONNTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
+                    (CONNRFTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
                 {
                     wStatus = NFCSTATUS_SUCCESS;
                 }
@@ -570,7 +570,7 @@ phNciNfc_GetConnMaxPldSz(
             if(bConnId == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)
             {
                 if((TRUE == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive) ||
-                    (CONNTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
+                    (CONNRFTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
                 {
                     *pMaxPldSz = gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bMaxDpldSize;
                     wStatus = NFCSTATUS_SUCCESS;
@@ -603,7 +603,7 @@ NFCSTATUS phNciNfc_IncrConnCredits(
         if(bConnId == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)
         {
             if((TRUE == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive) ||
-                (CONNTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
+                (CONNRFTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
             {
                 gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bNumCredits += bVal;
 
@@ -640,7 +640,7 @@ NFCSTATUS phNciNfc_DecrConnCredit(
         if(bConnId == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)
         {
             if((TRUE == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive) ||
-                (CONNTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
+                (CONNRFTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
             {
                 if(gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bNumCredits > 0)
                 {
@@ -720,7 +720,7 @@ static NFCSTATUS phNciNfc_GetConnIndex(uint8_t bConnId, uint8_t *pbConnIdx)
             if(bConnId == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId)
             {
                 if((TRUE == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].bIfActive) ||
-                    (CONNTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
+                    (CONNRFTYPE_STATIC == gphNciNfc_ConnMgmtInt.tConnInfo.tConnList[bConnListIdx].tConn.bConnId))
                 {
                     *pbConnIdx = bConnListIdx;
                     wStatus = NFCSTATUS_SUCCESS;

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
@@ -8,7 +8,7 @@
 
 #include "phNciNfc_Core.h"
 
-#define CONNTYPE_STATIC                 (0x00U)  /**< Static connection id/index */
+#define CONNRFTYPE_STATIC               (0x00U)  /**< Static RF connection id/index */
 #define MAX_LOGICAL_CONNS               (0x03U)  /**< Maximum number of Logical Connections Supported */
 #define INVALID_CONN_ID                 (0xFFU)  /**< Range beyond 15 is invalid connid */
 #define UNASSIGNED_DESTID               (0xFFU)  /**< Unassigned destination id */

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
@@ -16,6 +16,8 @@
 #define FLOW_CONTROL_DISABLED           (0xFFU)  /**< Flow control disabled during data exchange */
 #define MAX_CREDITS_LIMIT               (0xFEU)  /**< Max possible Credits for a connection */
 
+#define PHNCINFC_MIN_WAITCREDIT_TO      (250)
+
 typedef struct phNciNfc_LogConn_Rsp
 {
     uint8_t     bConnId;           /**< NFCC assigned Connection Identifier */

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_LoglConnMgmt.h
@@ -9,6 +9,7 @@
 #include "phNciNfc_Core.h"
 
 #define CONNRFTYPE_STATIC               (0x00U)  /**< Static RF connection id/index */
+#define CONNHCITYPE_STATIC              (0x01U)  /**< Static HCI connection id/index */
 #define MAX_LOGICAL_CONNS               (0x03U)  /**< Maximum number of Logical Connections Supported */
 #define INVALID_CONN_ID                 (0xFFU)  /**< Range beyond 15 is invalid connid */
 #define UNASSIGNED_DESTID               (0xFFU)  /**< Unassigned destination id */


### PR DESCRIPTION
Hi Ivan,

Please find in the following pull request fixes and code update following your feedbacks.
I believe I have been able to follow most of your feedbacks but still had to move the NCI versions
macros definitions from nfc/libs/NfcCoreLib/lib/Nci/phNciNfc.h  to nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h to allow correct debug output in nfc/libs/NfcCoreLib/lib/NciCore/phNciNfc_DbgDescription.c for NciCoreInitRsp. Indeed NciCoreInitRsp
does not follow the same format in Nci1.x and Nci2.x.

I have also fixed few mistakes on my side and left open future improvement for memcpy return value management within the full class extension.

I will follow up in a separate email with further information.

Best Regards
Christophe