### PR TITLE
Reader p2p rs2 fixes rc1

### DIFF
--- a/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Init.c
@@ -118,15 +118,6 @@ static NFCSTATUS phLibNfc_InitCb(void* pContext,NFCSTATUS wStatus,void* pInfo)
                         pLibContext->tSeInfo.bSeState[phLibNfc_SE_Index_HciNwk] = phLibNfc_SeStateInitializing;
                         pLibContext->sSeContext.pActiveSeInfo = (pphLibNfc_SE_List_t)(&pLibContext->tSeInfo.tSeList[phLibNfc_SE_Index_HciNwk]);
                     }
-
-                    /* RF_ISO_DEP_NAK_PRESENCE_CMD and CORE_SET_POWER_SUB_STATE_CMD are NCI2.0 commands.
-                     * If the Nci Version is 2.0 force those flags to 1.
-                     */
-                    if (PH_NCINFC_VERSION_IS_2x(pNciContext))
-                    {
-                        pLibContext->Config.bIsoDepPresChkCmd = 1;
-                        pLibContext->Config.bSwitchedOnSubState = 1;
-                    }
                 }else
                 {
                     wStatus = NFCSTATUS_FAILED;

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Discovery.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Discovery.c
@@ -1442,6 +1442,24 @@ static NFCSTATUS phNciNfc_DeActvNtfCb(void *pContext,void *pInfo,NFCSTATUS wStat
                         wDeActvStatus = NFCSTATUS_SUCCESS;
                     }
                 }
+                else if (pTransInfo->pbuffer[1] == (uint8_t)phNciNfc_e_DhRequestFailed)
+                {
+                    if ((pNciContext->NciDiscContext.eDeActvType == phNciNfc_e_SleepMode) && \
+                        (pTransInfo->pbuffer[0] == phNciNfc_e_SleepMode))
+                    {
+                        wDeActvStatus = NFCSTATUS_SUCCESS;
+                    }
+                    if ((pNciContext->NciDiscContext.eDeActvType == phNciNfc_e_SleepAfMode) && \
+                        (pTransInfo->pbuffer[0] == phNciNfc_e_SleepAfMode))
+                    {
+                        wDeActvStatus = NFCSTATUS_SUCCESS;
+                    }
+                    else if ((pNciContext->NciDiscContext.eDeActvType == phNciNfc_e_IdleMode) && \
+                             (pTransInfo->pbuffer[0] == phNciNfc_e_IdleMode))
+                    {
+                        wDeActvStatus = NFCSTATUS_SUCCESS;
+                    }
+                }
             }
         }
         /* Invoke upper layer if the Deactivate Notification timeout has occured */
@@ -1798,6 +1816,8 @@ NFCSTATUS phNciNfc_ProcessDeActvNtf(void* pContext, void *pInfo, NFCSTATUS statu
             case phNciNfc_e_NfcB_BadAfi:
                 tRfDeactvInfo.tRfDeactvInfo.eRfDeactvReason = phNciNfc_e_NfcB_BadAfi;
                 break;
+            case phNciNfc_e_DhRequestFailed:
+                tRfDeactvInfo.tRfDeactvInfo.eRfDeactvReason = phNciNfc_e_DhRequestFailed;
             default:
                 break;
             }

--- a/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
+++ b/nfc/libs/NfcCoreLib/lib/Nci/phNciNfc_Init.c
@@ -436,9 +436,6 @@ static void phNciNfc_ResetNtfDelayCb(uint32_t dwTimerId, void *pContext)
     if (NULL != pNciContext)
     {
         (void)phOsalNfc_Timer_Stop(pNciContext->dwNtfTimerId);
-        (void)phOsalNfc_Timer_Delete(pNciContext->dwNtfTimerId);
-
-        pNciContext->dwNtfTimerId = 0;
 
         wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
         if (wStatus != NFCSTATUS_SUCCESS)
@@ -506,8 +503,6 @@ NFCSTATUS phNciNfc_DelayForResetNtf(void* pContext)
             }
             else
             {
-                (void)phOsalNfc_Timer_Delete(pNciContext->dwNtfTimerId);
-                pNciContext->dwNtfTimerId = 0;
                 wStatus = NFCSTATUS_FAILED;
             }
         }
@@ -745,9 +740,6 @@ phNciNfc_ResetNtfCb(void*     pContext,
         if (pNciCtx->dwNtfTimerId != 0)
         {
             (void)phOsalNfc_Timer_Stop(pNciCtx->dwNtfTimerId);
-            (void)phOsalNfc_Timer_Delete(pNciCtx->dwNtfTimerId);
-
-            pNciCtx->dwNtfTimerId = 0;
 
             if (pTransInfo->wLength >= PHNFCINFC_CORE_RESET_NTF_MIN_LEN)
             {

--- a/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfcTypes.h
+++ b/nfc/libs/NfcCoreLib/lib/NciCore/phNciNfcTypes.h
@@ -220,7 +220,8 @@ typedef enum phNciNfc_DeActivateReason
     phNciNfc_e_DhRequest = 0,    /**<Deactivate to Idle Mode */
     phNciNfc_e_EndPoint = 1,   /**<Deactivate to Sleep Mode */
     phNciNfc_e_RfLinkLoss = 2,/**<Deactivate to SleepAF Mode */
-    phNciNfc_e_NfcB_BadAfi = 3   /**<Deactivate to Discovery Mode */
+    phNciNfc_e_NfcB_BadAfi = 3,   /**<Deactivate to Discovery Mode */
+    phNciNfc_e_DhRequestFailed = 4, /**<Deactivate to Idle Mode or Poll Active */
 }phNciNfc_DeActivateReason_t;
 
 /*!


### PR DESCRIPTION
Hi Ivan,

This 3 patches pull request brings
- a fix for the dwNfcTimer life cycle management introduced by "NCI: Handle NCI_RESET_RSP and NCI_RESET_NTF to manage NCI1.x and NCI2.x". 
- it revert patch "NCI2.0: RF_ISO_DEP_NAK_PRESENCE and CORE_SET_POWER_SUB_STATE_CMD" are NCI2.0 command". I have reconsidered this patch and believed it brings more constraints than any real value to an IHV. An IHV may not support one or/and the other command even in NCI2.0 for some reasons...
- It adds a missing deactivation reason added in the NCI2.0 specification for a RF_DEACTIVATE_NTF. This one got missed during the first cycle of integrating NCI2.0 in the class extension.

I don't know how likely those patch could be integrated in RS2 release..

Best Regards
Christophe.