### PR TITLE
Fix Type 1 tag CC version check

### DIFF
--- a/nfc/libs/NfcCoreLib/lib/Fri/phFriNfc_TopazDynamicMap.c
+++ b/nfc/libs/NfcCoreLib/lib/Fri/phFriNfc_TopazDynamicMap.c
@@ -114,6 +114,8 @@ so there are 4 segements in the card */
 #define TOPAZ_TOTAL_SEG_TO_READ                         (0x04U)
 /* SPEC version value shall be 0x10 as per the TYPE 1 specification */
 #define TOPAZ_SPEC_VERSION                              (0x10U)
+/* This mask is to get the major version from CC Byte 1 (Version) */
+#define TOPAZ_MAJOR_VERSION_BIT_MASK                    (0xF0U)
 
 /* Response length for READ SEGMENT command is 128 bytes */
 #define TOPAZ_SEGMENT_READ_LENGTH                       (0x80U)
@@ -2008,7 +2010,7 @@ phFriNfc_Tpz_H_CheckCCBytesForWrite (
     ps_tpz_info = &(psNdefMap->TopazContainer);
 
     if ((PH_FRINFC_TOPAZ_CC_BYTE0 != ps_tpz_info->CCByteBuf[0]) ||
-        (TOPAZ_SPEC_VERSION != ps_tpz_info->CCByteBuf[1]) ||
+        (TOPAZ_SPEC_VERSION != (ps_tpz_info->CCByteBuf[1] & TOPAZ_MAJOR_VERSION_BIT_MASK)) ||
         (PH_FRINFC_TOPAZ_DYNAMIC_CC_BYTE2_MMSIZE != ps_tpz_info->CCByteBuf[2]) ||
         (PH_FRINFC_TOPAZ_CC_READWRITE != ps_tpz_info->CCByteBuf[3]))
     {

--- a/nfc/libs/NfcCoreLib/lib/Fri/phFriNfc_TopazDynamicMap.c
+++ b/nfc/libs/NfcCoreLib/lib/Fri/phFriNfc_TopazDynamicMap.c
@@ -2010,7 +2010,7 @@ phFriNfc_Tpz_H_CheckCCBytesForWrite (
     ps_tpz_info = &(psNdefMap->TopazContainer);
 
     if ((PH_FRINFC_TOPAZ_CC_BYTE0 != ps_tpz_info->CCByteBuf[0]) ||
-        (TOPAZ_SPEC_VERSION != (ps_tpz_info->CCByteBuf[1] & TOPAZ_MAJOR_VERSION_BIT_MASK)) ||
+        ((TOPAZ_SPEC_VERSION & TOPAZ_MAJOR_VERSION_BIT_MASK) != (ps_tpz_info->CCByteBuf[1] & TOPAZ_MAJOR_VERSION_BIT_MASK)) ||
         (PH_FRINFC_TOPAZ_DYNAMIC_CC_BYTE2_MMSIZE != ps_tpz_info->CCByteBuf[2]) ||
         (PH_FRINFC_TOPAZ_CC_READWRITE != ps_tpz_info->CCByteBuf[3]))
     {


### PR DESCRIPTION
When attempting to write and NDEF to a Type 1 (Topaz) tag, the stack is checking the capability container (CC) version (byte 1) has a value of 0x10 (i.e. version 1.0). However, a type 1 tag could also be version 1.1 or 1.2 at this point in time. A version 1.x tag will be compatible with a stack using 1.0 features. Therefore, the version check should ignore minor version and only validate the major version is 1.