### PR TITLE
Ensure the correct ATR is returned from the smartcard interface.

### DIFF
--- a/nfc/NfcCx/Cx/NfcCxRF.h
+++ b/nfc/NfcCx/Cx/NfcCxRF.h
@@ -62,7 +62,6 @@ typedef struct _NFCCX_LIBNFC_CONTEXT {
     uint8_t                       ConfigStatus;
     HANDLE                        hNotifyCompleteEvent;
     phLibNfc_RemoteDevList_t*     pRemDevList;
-    NFCSTATUS                     DiscoveryStatus;
     BOOLEAN                       bIsTagPresent;
     BOOLEAN                       bIsTagConnected;
     BOOLEAN                       bIsTagNdefFormatted;


### PR DESCRIPTION
The ATR of a NFC tag can be provided during different stages of the NFC
discovery sequence, depending on the type of tag being read. Currently
NfcCx only ever caches ATRs retrieved during device discovery. This
change ensures that NfcCx also caches ATRs retrieved during device
connect.