### PR TITLE
Ese power management

### DIFF
--- a/libs/NfcCoreLib/inc/phLibNfc.h
+++ b/libs/NfcCoreLib/inc/phLibNfc.h
@@ -769,10 +769,10 @@ NFCSTATUS phLibNfc_SE_SetMode ( phLibNfc_Handle              hSE_Handle,
 * \retval   #NFCSTATUS_FAILED              Request failed
 */
 NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handle,
-    phLibNfc_PowerLinkModes_t  ePowerAndLinkModes,
-    pphLibNfc_RspCb_t  pSE_PowerAndLinkControl_Rsp_cb,
-    void *                       pContext
-);
+                                          phLibNfc_PowerLinkModes_t    ePowerAndLinkModes,
+                                          pphLibNfc_RspCb_t            pSE_PowerAndLinkControl_Rsp_cb,
+                                          void *                       pContext
+    );
 
 /**
 * \ingroup grp_lib_nfc

--- a/libs/NfcCoreLib/inc/phLibNfc.h
+++ b/libs/NfcCoreLib/inc/phLibNfc.h
@@ -69,15 +69,15 @@ typedef enum
 typedef enum phLibNfc_PowerLinkMode
 {
     /** NFCEE  NFCC decides identifier*/
-    phLibNfc_SE_NfccDecides = 0x00,
+    phLibNfc_PLM_NfccDecides = 0x00,
     /** NFCEE  power supply always on*/
-    phLibNfc_SE_PowerSupplyAlwaysOn = 0x01,
+    phLibNfc_PLM_PowerSupplyAlwaysOn = 0x01,
     /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
-    phLibNfc_SE_NfccComLinkActiveOnPowerOn = 0x02,
+    phLibNfc_PLM_ComLinkActiveWhenPowerOn = 0x02,
     /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
-    phLibNfc_SE_PowerNfccLinkAlwaysOn = 0x03,
+    phLibNfc_PLM_PowerAndComLinkAlwaysOn = 0x03,
     /** Future or unknown identifier */
-    phLibNfc_SE_PowerLinkUnknown,
+    phLibNfc_PLM_PowerLinkUnknown,
 }phLibNfc_PowerLinkModes_t;
 
 /** \ingroup grp_lib_nfc

--- a/libs/NfcCoreLib/inc/phLibNfc.h
+++ b/libs/NfcCoreLib/inc/phLibNfc.h
@@ -68,16 +68,11 @@ typedef enum
 */
 typedef enum phLibNfc_PowerLinkMode
 {
-    /** NFCEE  NFCC decides identifier*/
-    phLibNfc_PLM_NfccDecides = 0x00,
-    /** NFCEE  power supply always on*/
-    phLibNfc_PLM_PowerSupplyAlwaysOn = 0x01,
-    /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
-    phLibNfc_PLM_ComLinkActiveWhenPowerOn = 0x02,
-    /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
-    phLibNfc_PLM_PowerAndComLinkAlwaysOn = 0x03,
-    /** Future or unknown identifier */
-    phLibNfc_PLM_PowerLinkUnknown,
+    phLibNfc_PLM_NfccDecides = 0x00,                /** NFCEE  NFCC decides identifier*/
+    phLibNfc_PLM_PowerSupplyAlwaysOn = 0x01,        /** NFCEE  power supply always on*/
+    phLibNfc_PLM_ComLinkActiveWhenPowerOn = 0x02,   /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
+    phLibNfc_PLM_PowerAndComLinkAlwaysOn = 0x03,    /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
+    phLibNfc_PLM_PowerLinkUnknown,                  /** Future or unknown identifier */
 }phLibNfc_PowerLinkModes_t;
 
 /** \ingroup grp_lib_nfc

--- a/libs/NfcCoreLib/inc/phLibNfc.h
+++ b/libs/NfcCoreLib/inc/phLibNfc.h
@@ -62,6 +62,24 @@ typedef enum
     phLibNfc_SE_ActModeOff     = 0x01,
 }phLibNfc_eSE_ActivationMode;
 
+/**
+* \ingroup grp_nci_nfc
+* \brief NFCEE Power and Link Control Info contains power related identifier..
+*/
+typedef enum phLibNfc_PowerLinkMode
+{
+    /** NFCEE  NFCC decides identifier*/
+    phLibNfc_SE_NfccDecides = 0x00,
+    /** NFCEE  power supply always on*/
+    phLibNfc_SE_PowerSupplyAlwaysOn = 0x01,
+    /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
+    phLibNfc_SE_NfccComLinkActiveOnPowerOn = 0x02,
+    /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
+    phLibNfc_SE_PowerNfccLinkAlwaysOn = 0x03,
+    /** Future or unknown identifier */
+    phLibNfc_SE_PowerLinkUnknown,
+}phLibNfc_PowerLinkModes_t;
+
 /** \ingroup grp_lib_nfc
     SE event information */
 typedef union phLibNfc_uSeEvtInfo
@@ -720,6 +738,41 @@ NFCSTATUS phLibNfc_SE_SetMode ( phLibNfc_Handle              hSE_Handle,
                                 pphLibNfc_SE_SetModeRspCb_t  pSE_SetMode_Rsp_cb,
                                 void *                       pContext
     );
+
+/**
+* \ingroup grp_lib_nfc
+* \brief Sets power and link control configuration for the eSE secure element type.
+*
+* This function configures SE to different power mode.
+*
+* -# If mode is set to #phLibNfc_SE_NfccDecides then the NFCC will be responsible for powering
+* the eSE.
+* -# If mode is set to #phLibNfc_SE_PowerSupplyAlwaysOn then the NFCC will keep the eSE power
+* supply always on.
+* -# If mode is set to #phLibNfc_SE_NfccComLinkActiveOnPowerOn then the NFCC will keep the eSE
+* link always on.
+* -# If mode is set to #phLibNfc_SE_PowerNfccLinkAlwaysOn then the NFCC will keep the eSE
+* power supply and the link always on.
+*
+* \param[in]  hSE_Handle           Secure element handle
+* \param[in]  ePowerAndLinkModes   eSE power and link modes
+* \param[in]  pSE_PowerAndLinkControl_Rsp_cb   Pointer to response callback
+* \param[in]  pContext             Client context which will be included in
+*                                  callback when the request is completed.
+*
+* \retval   #NFCSTATUS_PENDING             SE power and link control transaction started
+* \retval   #NFCSTATUS_SHUTDOWN            Shutdown in progress
+* \retval   #NFCSTATUS_NOT_INITIALISED     LibNfc is not yet initialized
+* \retval   #NFCSTATUS_INVALID_HANDLE      Invalid handle
+* \retval   #NFCSTATUS_INVALID_PARAMETER   Invalid parameter
+* \retval   #NFCSTATUS_REJECTED            Invalid request
+* \retval   #NFCSTATUS_FAILED              Request failed
+*/
+NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handle,
+    phLibNfc_PowerLinkModes_t  ePowerAndLinkModes,
+    pphLibNfc_RspCb_t  pSE_PowerAndLinkControl_Rsp_cb,
+    void *                       pContext
+);
 
 /**
 * \ingroup grp_lib_nfc

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Internal.h
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Internal.h
@@ -222,6 +222,9 @@ typedef struct phLibNfc_CB_Info
     phLibNfc_NtfRegister_RspCb_t   pCeHostNtfCb;
     void                           *pCeHostNtfCntx;
 
+    pphLibNfc_RspCb_t               pPowerCtrlLinkCb;
+    void                            *pPowerCtrlLinkCntx;
+
     /* Se Get Atr Call back & it's context */
     pphLibNfc_GetAtrCallback_t     pSeClientGetAtrCb;
     void                           *pSeClientGetAtrCntx;
@@ -273,6 +276,7 @@ typedef enum phLibNfc_DummyEventType
     phLibNfc_DummyEventIsoDepChkPresExtn,   /**<Check presence IsoDep event*/
     phLibNfc_DummyEventChkPresMFC,          /**<Check presence extension event*/
     phLibNfc_DummyEventSetRtngCfg,          /**<Set routing table configuration event*/
+    phLibNfc_DummyEventPowerAndLinkCtrl,    /**<Set SE Power And Link Control*/
     phLibNfc_DummyEventInvalid              /**<Invalid Dummy event*/
 }phLibNfc_DummyEventType_t; /**< Dummy event enum type*/
 
@@ -286,6 +290,7 @@ typedef struct phLibNfc_SeCtxt
 {
     pphLibNfc_SE_List_t             pActiveSeInfo;
     phNciNfc_NfceeModes_t           eNfceeMode;
+    phNciNfc_PowerLinkModes_t       ePowerLinkMode;
     pphNciNfc_RtngConfig_t          pRoutingCfgBuffer;
     phLibNfc_eSE_ActivationMode     eActivationMode;    /* User rquested SE activation mode */
     uint32_t                        nNfceeDiscNtf;      /* Number of NFCEE discovery NTF to process */

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -1437,16 +1437,12 @@ static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFC
     pphLibNfc_LibContext_t pCtx = phLibNfc_GetContext();
     pphLibNfc_RspCb_t ClientCb = NULL;
     void *ClientContext = NULL;
-    phLibNfc_Handle hSeHandle;
     UNUSED(pInfo);
     PH_LOG_LIBNFC_FUNC_ENTRY();
     if ((NULL != pCtx) && (pContext == pCtx))
     {
         ClientCb = pCtx->CBInfo.pPowerCtrlLinkCb;
         ClientContext = pCtx->CBInfo.pPowerCtrlLinkCntx;
-        hSeHandle = pCtx->sSeContext.pActiveSeInfo->hSecureElement;
-
-        pCtx->StateContext.Flag = phLibNfc_StateTransitionComplete;
 
         if (NULL != ClientCb)
         {

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -319,7 +319,7 @@ NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handl
     }
     else
     {
-        wStatus = NFCSTATUS_FAILED;
+        wStatus = NFCSTATUS_FEATURE_NOT_SUPPORTED;
     }
     PH_LOG_LIBNFC_FUNC_EXIT();
     return wStatus;

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -319,6 +319,7 @@ NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handl
     }
     else
     {
+        PH_LOG_LIBNFC_CRIT_STR("NFCC is not operating in NCI2.0 mode!");
         wStatus = NFCSTATUS_FEATURE_NOT_SUPPORTED;
     }
     PH_LOG_LIBNFC_FUNC_EXIT();

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -1435,18 +1435,18 @@ static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFC
 {
     NFCSTATUS wStatus = Status;
     pphLibNfc_LibContext_t pCtx = phLibNfc_GetContext();
-    pphLibNfc_RspCb_t ClientCb = NULL;
-    void *ClientContext = NULL;
+    pphLibNfc_RspCb_t clientCb = NULL;
+    void *clientContext = NULL;
     UNUSED(pInfo);
     PH_LOG_LIBNFC_FUNC_ENTRY();
     if ((NULL != pCtx) && (pContext == pCtx))
     {
-        ClientCb = pCtx->CBInfo.pPowerCtrlLinkCb;
-        ClientContext = pCtx->CBInfo.pPowerCtrlLinkCntx;
+        clientCb = pCtx->CBInfo.pPowerCtrlLinkCb;
+        clientContext = pCtx->CBInfo.pPowerCtrlLinkCntx;
 
-        if (NULL != ClientCb)
+        if (NULL != clientCb)
         {
-            ClientCb(ClientContext, wStatus);
+            clientCb(clientContext, wStatus);
         }
     }
     else

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -295,8 +295,13 @@ NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handl
 
     wStatus = phLibNfc_IsInitialised(pCtx);
 
-    if ((NULL == (void *)hSE_Handle) ||
-        (NULL == pSE_PowerAndLinkControl_Rsp_cb))
+    if (NFCSTATUS_SUCCESS != wStatus)
+    {
+        PH_LOG_LIBNFC_CRIT_STR("LibNfc Stack not Initialised");
+        wStatus = NFCSTATUS_NOT_INITIALISED;
+    }
+    else if ((NULL == (void *)hSE_Handle) ||
+             (NULL == pSE_PowerAndLinkControl_Rsp_cb))
     {
         wStatus = NFCSTATUS_INVALID_PARAMETER;
     }

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -12,6 +12,10 @@ static NFCSTATUS phLibNfc_SetModeSeq(void *pContext, NFCSTATUS wStatus, void *pI
 static NFCSTATUS phLibNfc_SetModeSeqEnd(void* pContext, NFCSTATUS status, void* pInfo);
 static NFCSTATUS phLibNfc_SetSeModeSeqComplete(void* pContext, NFCSTATUS Status, void *pInfo);
 
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlSeq(void *pContext, NFCSTATUS wStatus, void *pInfo);
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlEnd(void* pContext, NFCSTATUS status, void* pInfo);
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFCSTATUS Status, void *pInfo);
+
 static NFCSTATUS phLibNfc_StartNfceeDisc(void* pContext, NFCSTATUS status, void* pInfo);
 static NFCSTATUS phLibNfc_ProcessStartNfceeDiscRsp(void* pContext, NFCSTATUS wStatus, void* pInfo);
 static NFCSTATUS phLibNfc_NfceeStartDiscSeqComplete(void *pContext, NFCSTATUS Status, void *pInfo);
@@ -44,6 +48,12 @@ phLibNfc_Sequence_t gphLibNfc_SetSeModeSeq[] = {
     {&phLibNfc_SetModeSeq, &phLibNfc_SetModeSeqEnd},
     {&phLibNfc_DelayForSeNtf, &phLibNfc_DelayForSeNtfProc},
     {NULL, &phLibNfc_SetSeModeSeqComplete}
+};
+
+/* NFCEE power and link control sequence */
+phLibNfc_Sequence_t gphLibNfc_SePowerAndLinkCtrlSeq[] = {
+    { &phLibNfc_SePowerAndLinkCtrlSeq, &phLibNfc_SePowerAndLinkCtrlEnd },
+    { NULL, &phLibNfc_SePowerAndLinkCtrlCompleteSequence }
 };
 
 /* NFCEE discovery sequence */
@@ -266,6 +276,50 @@ NFCSTATUS phLibNfc_SE_SetMode ( phLibNfc_Handle              hSE_Handle,
             pCtx->CBInfo.pSeSetModeCb = pSE_SetMode_Rsp_cb;
             pCtx->CBInfo.pSeSetModeCtxt = pContext;
         }
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return wStatus;
+}
+
+NFCSTATUS phLibNfc_SE_PowerAndLinkControl(phLibNfc_Handle              hSE_Handle,
+                                          phLibNfc_PowerLinkModes_t    powerLinkModes,
+                                          pphLibNfc_RspCb_t            pSE_PowerAndLinkControl_Rsp_cb,
+                                          void *                       pContext
+                                         )
+{
+    NFCSTATUS      wStatus = NFCSTATUS_SUCCESS;
+    pphLibNfc_Context_t pCtx = phLibNfc_GetContext();
+    phLibNfc_Event_t TrigEvent = phLibNfc_EventDummy;
+    phLibNfc_DummyInfo_t Info;
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+
+    wStatus = phLibNfc_IsInitialised(pCtx);
+
+    if ((NULL == (void *)hSE_Handle) ||
+        (NULL == pSE_PowerAndLinkControl_Rsp_cb))
+    {
+        wStatus = NFCSTATUS_INVALID_PARAMETER;
+    }
+    else if (phNciNfc_IsVersion2x(pCtx->sHwReference.pNciHandle))
+    {
+        Info.Evt = phLibNfc_DummyEventPowerAndLinkCtrl;
+
+        Info.Params = (void *)&powerLinkModes;
+        wStatus = phLibNfc_StateHandler(pCtx,
+                                        TrigEvent,
+                                        (void *)hSE_Handle, /*Secure Element Handle*/
+                                        (void *)&Info, /*Information for setting Power and Link for SE*/
+                                        NULL);
+        if (NFCSTATUS_PENDING == wStatus)
+        {
+            /*Store CB info in SE Context*/
+            pCtx->CBInfo.pPowerCtrlLinkCb = pSE_PowerAndLinkControl_Rsp_cb;
+            pCtx->CBInfo.pPowerCtrlLinkCntx = pContext;
+        }
+    }
+    else
+    {
+        wStatus = NFCSTATUS_FAILED;
     }
     PH_LOG_LIBNFC_FUNC_EXIT();
     return wStatus;
@@ -1319,6 +1373,84 @@ static NFCSTATUS phLibNfc_SetSeModeSeqComplete (void* pContext,NFCSTATUS Status,
         if(NULL != ClientCb)
         {
             ClientCb(ClientContext, hSeHandle, wStatus);
+        }
+    }
+    else
+    {
+        PH_LOG_LIBNFC_CRIT_STR("Invalid input parameter!");
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return wStatus;
+}
+
+static NFCSTATUS
+phLibNfc_SePowerAndLinkCtrlSeq(void *pContext,
+                               NFCSTATUS wStatus,
+                               void *pInfo)
+{
+    NFCSTATUS wIntStatus = wStatus;
+    pphLibNfc_LibContext_t pLibContext = (pphLibNfc_LibContext_t)pContext;
+    UNUSED(pInfo);
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    if ((NULL != pLibContext) && (phLibNfc_GetContext() == pLibContext))
+    {
+        if (NFCSTATUS_SUCCESS == wIntStatus)
+        {
+            wIntStatus = phNciNfc_Nfcee_SePowerAndLinkCtrlSet(pLibContext->sHwReference.pNciHandle,
+                                    (void *)pLibContext->sSeContext.pActiveSeInfo->hSecureElement,
+                                    pLibContext->sSeContext.ePowerLinkMode,
+                                    (pphNciNfc_IfNotificationCb_t)&phLibNfc_InternalSequence,
+                                    (void *)pLibContext);
+        }
+    }
+    else
+    {
+        PH_LOG_LIBNFC_CRIT_STR("Invalid Context passed from lower layer!");
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return wIntStatus;
+}
+
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlEnd(void *pContext, NFCSTATUS wStatus, void *pInfo)
+{
+    pphLibNfc_LibContext_t pLibContext = pContext;
+    UNUSED(pInfo);
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    if ((NULL != pLibContext) && (phLibNfc_GetContext() == pLibContext))
+    {
+        if (NFCSTATUS_SUCCESS == wStatus)
+        {
+            PH_LOG_LIBNFC_INFO_STR("Set Se Power Mode success");
+        }
+        else
+        {
+            PH_LOG_LIBNFC_CRIT_STR("Set Se Power Mode Failed!");
+        }
+    }
+    PH_LOG_LIBNFC_FUNC_EXIT();
+    return wStatus;
+}
+
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFCSTATUS Status, void *pInfo)
+{
+    NFCSTATUS wStatus = Status;
+    pphLibNfc_LibContext_t pCtx = phLibNfc_GetContext();
+    pphLibNfc_RspCb_t ClientCb = NULL;
+    void *ClientContext = NULL;
+    phLibNfc_Handle hSeHandle;
+    UNUSED(pInfo);
+    PH_LOG_LIBNFC_FUNC_ENTRY();
+    if ((NULL != pCtx) && (pContext == pCtx))
+    {
+        ClientCb = pCtx->CBInfo.pPowerCtrlLinkCb;
+        ClientContext = pCtx->CBInfo.pPowerCtrlLinkCntx;
+        hSeHandle = pCtx->sSeContext.pActiveSeInfo->hSecureElement;
+
+        pCtx->StateContext.Flag = phLibNfc_StateTransitionComplete;
+
+        if (NULL != ClientCb)
+        {
+            ClientCb(ClientContext, wStatus);
         }
     }
     else

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -1418,11 +1418,7 @@ static NFCSTATUS phLibNfc_SePowerAndLinkCtrlEnd(void *pContext, NFCSTATUS wStatu
     PH_LOG_LIBNFC_FUNC_ENTRY();
     if ((NULL != pLibContext) && (phLibNfc_GetContext() == pLibContext))
     {
-        if (NFCSTATUS_SUCCESS == wStatus)
-        {
-            PH_LOG_LIBNFC_INFO_STR("Set Se Power Mode success");
-        }
-        else
+        if (NFCSTATUS_SUCCESS != wStatus)
         {
             PH_LOG_LIBNFC_CRIT_STR("Set Se Power Mode Failed!");
         }

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -1388,20 +1388,18 @@ phLibNfc_SePowerAndLinkCtrlSeq(void *pContext,
                                NFCSTATUS wStatus,
                                void *pInfo)
 {
-    NFCSTATUS wIntStatus = wStatus;
+    NFCSTATUS wIntStatus = NFCSTATUS_FAILED;
     pphLibNfc_LibContext_t pLibContext = (pphLibNfc_LibContext_t)pContext;
     UNUSED(pInfo);
+    UNUSED(wStatus);
     PH_LOG_LIBNFC_FUNC_ENTRY();
     if ((NULL != pLibContext) && (phLibNfc_GetContext() == pLibContext))
     {
-        if (NFCSTATUS_SUCCESS == wIntStatus)
-        {
-            wIntStatus = phNciNfc_Nfcee_SePowerAndLinkCtrlSet(pLibContext->sHwReference.pNciHandle,
-                                    (void *)pLibContext->sSeContext.pActiveSeInfo->hSecureElement,
-                                    pLibContext->sSeContext.ePowerLinkMode,
-                                    (pphNciNfc_IfNotificationCb_t)&phLibNfc_InternalSequence,
-                                    (void *)pLibContext);
-        }
+        wIntStatus = phNciNfc_Nfcee_SePowerAndLinkCtrlSet(pLibContext->sHwReference.pNciHandle,
+                                (void *)pLibContext->sSeContext.pActiveSeInfo->hSecureElement,
+                                pLibContext->sSeContext.ePowerLinkMode,
+                                (pphNciNfc_IfNotificationCb_t)&phLibNfc_InternalSequence,
+                                (void *)pLibContext);
     }
     else
     {

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.c
@@ -1431,9 +1431,8 @@ static NFCSTATUS phLibNfc_SePowerAndLinkCtrlEnd(void *pContext, NFCSTATUS wStatu
     return wStatus;
 }
 
-static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFCSTATUS Status, void *pInfo)
+static NFCSTATUS phLibNfc_SePowerAndLinkCtrlCompleteSequence(void* pContext, NFCSTATUS wStatus, void *pInfo)
 {
-    NFCSTATUS wStatus = Status;
     pphLibNfc_LibContext_t pCtx = phLibNfc_GetContext();
     pphLibNfc_RspCb_t clientCb = NULL;
     void *clientContext = NULL;

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.h
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Se.h
@@ -19,6 +19,7 @@
 #define PH_LIBNFC_SE_LSTN_NFC_F_SUPP    0x04
 
 extern phLibNfc_Sequence_t gphLibNfc_SetSeModeSeq[];
+extern phLibNfc_Sequence_t gphLibNfc_SePowerAndLinkCtrlSeq[];
 
 #include <phNfcStatus.h>
 #include "phNciNfcTypes.h"

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_State.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_State.c
@@ -655,6 +655,18 @@ static NFCSTATUS phLibNfc_DummyFunc(void *pContext, void *Param1, void *Param2, 
                 }
             }
             break;
+            case phLibNfc_DummyEventPowerAndLinkCtrl:
+            {
+                pLibContext->sSeContext.ePowerLinkMode = *(phNciNfc_PowerLinkModes_t *)(pInfo->Params);
+
+                PHLIBNFC_INIT_SEQUENCE(pLibContext, gphLibNfc_SePowerAndLinkCtrlSeq);
+                wStatus = phLibNfc_SeqHandler(pLibContext, NFCSTATUS_SUCCESS, NULL);
+                if (NFCSTATUS_PENDING != wStatus)
+                {
+                    wStatus = NFCSTATUS_FAILED;
+                }
+            }
+            break;
             case phLibNfc_DummyEventSetP2PConfigs:
             {
                 pRfConfParam = (pphNciNfc_RfDiscConfigParams_t) pInfo->Params;

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -692,12 +692,12 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
     PH_LOG_NCI_FUNC_ENTRY();
     if (NULL == pNciContext)
     {
-        PH_LOG_NCI_CRIT_STR("Stack not initialized (phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+        PH_LOG_NCI_CRIT_STR("Stack not initialized");
         wStatus = NFCSTATUS_NOT_INITIALISED;
     }
     else if (NULL == pNotifyCb)
     {
-        PH_LOG_NCI_CRIT_STR("Invalid parameter passed(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+        PH_LOG_NCI_CRIT_STR("Invalid parameter passed");
         wStatus = NFCSTATUS_INVALID_PARAMETER;
     }
     else
@@ -711,7 +711,7 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
                 pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PHNCINFC_NFCEEMODESET_PAYLOADLEN);
                 if (NULL == pTargetInfo)
                 {
-                    PH_LOG_NCI_CRIT_STR("Memory not available(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+                    PH_LOG_NCI_CRIT_STR("Memory not available");
                     wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
                 }
                 else

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -685,7 +685,7 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
 {
     NFCSTATUS wStatus = NFCSTATUS_SUCCESS;
     phNciNfc_Context_t * pNciContext = (phNciNfc_Context_t *)pNciHandle;
-    pphNciNfc_NfceeDeviceHandle_t pDevHandle = \
+    pphNciNfc_NfceeDeviceHandle_t pDevHandle =
         (pphNciNfc_NfceeDeviceHandle_t)pNfceeHandle;
     uint8_t *pTargetInfo;
 
@@ -702,8 +702,8 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
     }
     else
     {
-        if ((NULL != pDevHandle) && \
-            (0 != pDevHandle->tDevInfo.bNfceeID) && \
+        if ((NULL != pDevHandle) &&
+            (0 != pDevHandle->tDevInfo.bNfceeID) &&
             (PHNCINFC_INVALID_DISCID != pDevHandle->tDevInfo.bNfceeID))
         {
             if (phNciNfc_IsVersion2x(pNciContext))
@@ -720,7 +720,7 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
                     pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
                     pTargetInfo[1] = (uint8_t)eActivationMode;
                     pNciContext->tSendPayload.pBuff = pTargetInfo;
-                    pNciContext->tSendPayload.wPayloadSize = \
+                    pNciContext->tSendPayload.wPayloadSize =
                         (uint16_t)PHNCINFC_NFCEEMODESET_PAYLOADLEN;
                     pNciContext->IfNtf = pNotifyCb;
                     pNciContext->IfNtfCtx = pContext;

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -706,37 +706,30 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
             (0 != pDevHandle->tDevInfo.bNfceeID) &&
             (PHNCINFC_INVALID_DISCID != pDevHandle->tDevInfo.bNfceeID))
         {
-            if (phNciNfc_IsVersion2x(pNciContext))
+            pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PH_NCINFC_NFCEEPOWERLINKCTRL_PAYLOADLEN);
+            if (NULL == pTargetInfo)
             {
-                pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PHNCINFC_NFCEEMODESET_PAYLOADLEN);
-                if (NULL == pTargetInfo)
-                {
-                    PH_LOG_NCI_CRIT_STR("Memory not available");
-                    wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
-                }
-                else
-                {
-                    /* Store the Payload */
-                    pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
-                    pTargetInfo[1] = (uint8_t)eActivationMode;
-                    pNciContext->tSendPayload.pBuff = pTargetInfo;
-                    pNciContext->tSendPayload.wPayloadSize =
-                        (uint16_t)PHNCINFC_NFCEEMODESET_PAYLOADLEN;
-                    pNciContext->IfNtf = pNotifyCb;
-                    pNciContext->IfNtfCtx = pContext;
-                    PHNCINFC_INIT_SEQUENCE(pNciContext, gphNciNfc_SePowerAndLinkCtrlSequence);
-                    wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
-                    if (NFCSTATUS_PENDING != wStatus)
-                    {
-                        PH_LOG_NCI_CRIT_STR("Nfcee PowerAndLinkCtrlSet Sequence failed!");
-                        phOsalNfc_FreeMemory(pTargetInfo);
-                        pNciContext->tSendPayload.pBuff = NULL;
-                    }
-                }
+                PH_LOG_NCI_CRIT_STR("Memory not available");
+                wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
             }
             else
             {
-                wStatus = NFCSTATUS_FEATURE_NOT_SUPPORTED;
+                /* Store the Payload */
+                pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
+                pTargetInfo[1] = (uint8_t)eActivationMode;
+                pNciContext->tSendPayload.pBuff = pTargetInfo;
+                pNciContext->tSendPayload.wPayloadSize =
+                    (uint16_t)PH_NCINFC_NFCEEPOWERLINKCTRL_PAYLOADLEN;
+                pNciContext->IfNtf = pNotifyCb;
+                pNciContext->IfNtfCtx = pContext;
+                PHNCINFC_INIT_SEQUENCE(pNciContext, gphNciNfc_SePowerAndLinkCtrlSequence);
+                wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+                if (NFCSTATUS_PENDING != wStatus)
+                {
+                    PH_LOG_NCI_CRIT_STR("Nfcee PowerAndLinkCtrlSet Sequence failed!");
+                    phOsalNfc_FreeMemory(pTargetInfo);
+                    pNciContext->tSendPayload.pBuff = NULL;
+                }
             }
         }
         else

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -677,6 +677,70 @@ NFCSTATUS phNciNfc_Nfcee_ModeSet(void * pNciHandle,
     return wStatus;
 }
 
+NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
+                                               void * pNfceeHandle,
+                                               phNciNfc_PowerLinkModes_t eActivationMode,
+                                               pphNciNfc_IfNotificationCb_t pNotifyCb,
+                                               void *pContext)
+{
+    NFCSTATUS wStatus = NFCSTATUS_SUCCESS;
+    phNciNfc_Context_t * pNciContext = (phNciNfc_Context_t *)pNciHandle;
+    pphNciNfc_NfceeDeviceHandle_t pDevHandle = \
+        (pphNciNfc_NfceeDeviceHandle_t)pNfceeHandle;
+    uint8_t *pTargetInfo;
+
+    PH_LOG_NCI_FUNC_ENTRY();
+    if (NULL == pNciContext)
+    {
+        PH_LOG_NCI_CRIT_STR("Stack not initialized (phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+        wStatus = NFCSTATUS_NOT_INITIALISED;
+    }
+    else if (NULL == pNotifyCb)
+    {
+        PH_LOG_NCI_CRIT_STR("Invalid parameter passed(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+        wStatus = NFCSTATUS_INVALID_PARAMETER;
+    }
+    else
+    {
+        if ((NULL != pDevHandle) && \
+            (0 != pDevHandle->tDevInfo.bNfceeID) && \
+            (PHNCINFC_INVALID_DISCID != pDevHandle->tDevInfo.bNfceeID))
+        {
+            pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PHNCINFC_NFCEEMODESET_PAYLOADLEN);
+            if (NULL == pTargetInfo)
+            {
+                PH_LOG_NCI_CRIT_STR("Memory not available(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+                wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
+            }
+            else if (phNciNfc_IsVersion2x(pNciContext))
+            {
+                /* Store the Payload */
+                pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
+                pTargetInfo[1] = (uint8_t)eActivationMode;
+                pNciContext->tSendPayload.pBuff = pTargetInfo;
+                pNciContext->tSendPayload.wPayloadSize = \
+                    (uint16_t)PHNCINFC_NFCEEMODESET_PAYLOADLEN;
+                pNciContext->IfNtf = pNotifyCb;
+                pNciContext->IfNtfCtx = pContext;
+                PHNCINFC_INIT_SEQUENCE(pNciContext, gphNciNfc_SePowerAndLinkCtrlSequence);
+                wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+                if (NFCSTATUS_PENDING != wStatus)
+                {
+                    PH_LOG_NCI_CRIT_STR("Nfcee PowerAndLinkCtrlSet Sequence failed!");
+                    phOsalNfc_FreeMemory(pTargetInfo);
+                    pNciContext->tSendPayload.pBuff = NULL;
+                }
+            }
+        }
+        else
+        {
+            wStatus = NFCSTATUS_INVALID_PARAMETER;
+        }
+    }
+    PH_LOG_NCI_FUNC_EXIT();
+    return wStatus;
+}
+
 NFCSTATUS phNciNfc_RegisterNotification(
                         void                        *pNciHandle,
                         phNciNfc_RegisterType_t     eRegisterType,

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.c
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.c
@@ -706,30 +706,37 @@ NFCSTATUS phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
             (0 != pDevHandle->tDevInfo.bNfceeID) && \
             (PHNCINFC_INVALID_DISCID != pDevHandle->tDevInfo.bNfceeID))
         {
-            pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PHNCINFC_NFCEEMODESET_PAYLOADLEN);
-            if (NULL == pTargetInfo)
+            if (phNciNfc_IsVersion2x(pNciContext))
             {
-                PH_LOG_NCI_CRIT_STR("Memory not available(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
-                wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
-            }
-            else if (phNciNfc_IsVersion2x(pNciContext))
-            {
-                /* Store the Payload */
-                pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
-                pTargetInfo[1] = (uint8_t)eActivationMode;
-                pNciContext->tSendPayload.pBuff = pTargetInfo;
-                pNciContext->tSendPayload.wPayloadSize = \
-                    (uint16_t)PHNCINFC_NFCEEMODESET_PAYLOADLEN;
-                pNciContext->IfNtf = pNotifyCb;
-                pNciContext->IfNtfCtx = pContext;
-                PHNCINFC_INIT_SEQUENCE(pNciContext, gphNciNfc_SePowerAndLinkCtrlSequence);
-                wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
-                if (NFCSTATUS_PENDING != wStatus)
+                pTargetInfo = (uint8_t *)phOsalNfc_GetMemory(PHNCINFC_NFCEEMODESET_PAYLOADLEN);
+                if (NULL == pTargetInfo)
                 {
-                    PH_LOG_NCI_CRIT_STR("Nfcee PowerAndLinkCtrlSet Sequence failed!");
-                    phOsalNfc_FreeMemory(pTargetInfo);
-                    pNciContext->tSendPayload.pBuff = NULL;
+                    PH_LOG_NCI_CRIT_STR("Memory not available(phNciNfc_Nfcee_SePowerAndLinkCtrlSet)");
+                    wStatus = NFCSTATUS_INSUFFICIENT_RESOURCES;
                 }
+                else
+                {
+                    /* Store the Payload */
+                    pTargetInfo[0] = pDevHandle->tDevInfo.bNfceeID;
+                    pTargetInfo[1] = (uint8_t)eActivationMode;
+                    pNciContext->tSendPayload.pBuff = pTargetInfo;
+                    pNciContext->tSendPayload.wPayloadSize = \
+                        (uint16_t)PHNCINFC_NFCEEMODESET_PAYLOADLEN;
+                    pNciContext->IfNtf = pNotifyCb;
+                    pNciContext->IfNtfCtx = pContext;
+                    PHNCINFC_INIT_SEQUENCE(pNciContext, gphNciNfc_SePowerAndLinkCtrlSequence);
+                    wStatus = phNciNfc_GenericSequence(pNciContext, NULL, wStatus);
+                    if (NFCSTATUS_PENDING != wStatus)
+                    {
+                        PH_LOG_NCI_CRIT_STR("Nfcee PowerAndLinkCtrlSet Sequence failed!");
+                        phOsalNfc_FreeMemory(pTargetInfo);
+                        pNciContext->tSendPayload.pBuff = NULL;
+                    }
+                }
+            }
+            else
+            {
+                wStatus = NFCSTATUS_FEATURE_NOT_SUPPORTED;
             }
         }
         else

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -293,16 +293,11 @@ typedef enum phNciNfc_NfceeModes
 */
 typedef enum phNciNfc_PowerLinkMode
 {
-    /** NFCEE  NFCC decides identifier*/
-    phNciNfc_PLM_NfccDecides = 0x00,
-    /** NFCEE  power supply always on*/
-    phNciNfc_PLM_PowerSupplyAlwaysOn = 0x01,
-    /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
-    phNciNfc_PLM_ComLinkActiveOnPowerOn = 0x02,
-    /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
-    phNciNfc_PLM_PowerNfccLinkAlwaysOn = 0x03,
-    /** Future or unknown identifier */
-    phNciNfc_PLM_PowerLinkUnknown,
+    phNciNfc_PLM_NfccDecides = 0x00,            /** NFCEE  NFCC decides identifier*/
+    phNciNfc_PLM_PowerSupplyAlwaysOn = 0x01,    /** NFCEE  power supply always on*/
+    phNciNfc_PLM_ComLinkActiveOnPowerOn = 0x02, /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
+    phNciNfc_PLM_PowerNfccLinkAlwaysOn = 0x03,  /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
+    phNciNfc_PLM_PowerLinkUnknown,              /** Future or unknown identifier */
 }phNciNfc_PowerLinkModes_t;
 
 /*!

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -287,6 +287,24 @@ typedef enum phNciNfc_NfceeModes
    PH_NCINFC_NFCEEDISC_UNKNOWN
 }phNciNfc_NfceeModes_t;
 
+/**
+* \ingroup grp_nci_nfc
+* \brief NFCEE Power and Link Control Info contains power related identifier..
+*/
+typedef enum phNciNfc_PowerLinkMode
+{
+    /** NFCEE  NFCC decides identifier*/
+    phNciNfc_NfceeNfccDecides = 0x00,
+    /** NFCEE  power supply always on*/
+    phNciNfc_NfceePowerSupplyAlwaysOn = 0x01,
+    /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
+    phNciNfc_NfceeComLinkActiveOnPowerOn = 0x02,
+    /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
+    phNciNfc_NfceePowerNfccLinkAlwaysOn = 0x03,
+    /** Future or unknown identifier */
+    phNciNfc_NfceePowerLinkUnknown,
+}phNciNfc_PowerLinkModes_t;
+
 /*!
  * \ingroup grp_nci_nfc
  * \brief NFCEE Information TLV types(NCI Spec Table 84)
@@ -1478,6 +1496,31 @@ phNciNfc_Nfcee_ModeSet(void * pNciHandle,
                        phNciNfc_NfceeModes_t eNfceeMode,
                        pphNciNfc_IfNotificationCb_t pNotifyCb,
                        void *pContext);
+
+/**
+* \ingroup grp_nci_nfc
+*
+* \brief This is a Nfcee power mode set Api, to establish a control power with
+* a SE or NFCEE.(establishing connection is prereqisite of Nfcee communication)
+*
+* \param[in]  pNciHandle        NCI layer specific context.
+* \param[in]  pNfceeHandle      Nfcee Handle for which Mode set is executed.
+* \param[in]  eActivationMode   NFCEE and NFCC Power and Link mode
+* \param[in]  pNotifyCb         Upper layer call back function
+* \param[in]  pContext          Context of the Upper Layer.
+*
+* \retval NFCSTATUS_PENDING                If the command is yet to be processed.
+* \retval NFCSTATUS_INVALID_PARAMETER      At least one parameter of the function is invalid.
+* \retval NFCSTATUS_INVALID_DEVICE         The device has not been opened or has
+*                                          been disconnected meanwhile
+*/
+extern NFCSTATUS
+phNciNfc_Nfcee_SePowerAndLinkCtrlSet(void * pNciHandle,
+                                     void * pNfceeHandle,
+                                     phNciNfc_PowerLinkModes_t eActivationMode,
+                                     pphNciNfc_IfNotificationCb_t pNotifyCb,
+                                     void *pContext);
+
 
 /**
  * \ingroup grp_nci_nfc

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc.h
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc.h
@@ -294,15 +294,15 @@ typedef enum phNciNfc_NfceeModes
 typedef enum phNciNfc_PowerLinkMode
 {
     /** NFCEE  NFCC decides identifier*/
-    phNciNfc_NfceeNfccDecides = 0x00,
+    phNciNfc_PLM_NfccDecides = 0x00,
     /** NFCEE  power supply always on*/
-    phNciNfc_NfceePowerSupplyAlwaysOn = 0x01,
+    phNciNfc_PLM_PowerSupplyAlwaysOn = 0x01,
     /** NFCEE  NFCC to NFCEE Communication link always active when the NFCEE is powered on*/
-    phNciNfc_NfceeComLinkActiveOnPowerOn = 0x02,
+    phNciNfc_PLM_ComLinkActiveOnPowerOn = 0x02,
     /** NFCEE Power supply and NFCC to NFCEE communication link are always on*/
-    phNciNfc_NfceePowerNfccLinkAlwaysOn = 0x03,
+    phNciNfc_PLM_PowerNfccLinkAlwaysOn = 0x03,
     /** Future or unknown identifier */
-    phNciNfc_NfceePowerLinkUnknown,
+    phNciNfc_PLM_PowerLinkUnknown,
 }phNciNfc_PowerLinkModes_t;
 
 /*!

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc_NfceeMgmt.h
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc_NfceeMgmt.h
@@ -51,6 +51,7 @@ typedef void (*pphNciNfc_Notification_CB_t) (
 
 extern phNciNfc_SequenceP_t gphNciNfc_NfceeDiscSequence[];
 extern phNciNfc_SequenceP_t gphNciNfc_ModeSetSequence[];
+extern phNciNfc_SequenceP_t gphNciNfc_SePowerAndLinkCtrlSequence[];
 
 NFCSTATUS phNciNfc_DeActivateNfcee(void *pContext);
 NFCSTATUS phNciNfc_RfFieldInfoNtfHandler(void *pContext, void *pInfo,NFCSTATUS Status);

--- a/libs/NfcCoreLib/lib/Nci/phNciNfc_NfceeMgmt.h
+++ b/libs/NfcCoreLib/lib/Nci/phNciNfc_NfceeMgmt.h
@@ -29,6 +29,8 @@
 #define PH_NCINFC_NFCEE_PROTOS_PROP_MIN             (0x80)
 #define PH_NCINFC_NFCEE_PROTOS_PROP_MAX             (0xFE)
 
+#define PH_NCINFC_NFCEEPOWERLINKCTRL_PAYLOADLEN     (0x02)
+
 typedef struct phNciNfc_NfceeContext
 {
     /** Total number of Nfcee discovered from response*/

--- a/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.c
+++ b/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.c
@@ -26,6 +26,7 @@
 #define PHNCINFC_CORE_NFCEEDISC_CMD_PAYLOADLEN_1x           (1U)
 #define PHNCINFC_CORE_NFCEEDISC_CMD_PAYLOADLEN_2x           (0U)
 #define PHNCINFC_CORE_NFCEEMODESET_CMD_PAYLOADLEN           (2U)
+#define PHNCINFC_CORE_NFCEEPOWERANDLINKCTRL_CMD_PAYLOADLEN  (2U)
 
 #define PHNCINFC_CORE_TESTANTENNA_CMD_PAYLOADMINLEN         (2U)
 #define PHNCINFC_CORE_TESTANTENNA_CMD_PAYLOADMAXLEN         (4U)
@@ -610,6 +611,12 @@ phNciNfc_CoreValidateNfceeMgtCmd(pphNciNfc_CoreTxInfo_t pTxInfo,
             break;
         case phNciNfc_e_NfceeMgtModeSetCmdOid:
             if((PHNCINFC_CORE_NFCEEMODESET_CMD_PAYLOADLEN == pTxInfo->wLen) && (NULL != pTxInfo->Buff))
+            {
+                wStatus = NFCSTATUS_SUCCESS;
+            }
+            break;
+        case phNciNfc_e_NfceeMgtPowerAndLinkCtrlCmdOid:
+            if ((PHNCINFC_CORE_NFCEEMODESET_CMD_PAYLOADLEN == pTxInfo->wLen) && (NULL != pTxInfo->Buff))
             {
                 wStatus = NFCSTATUS_SUCCESS;
             }

--- a/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.c
+++ b/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.c
@@ -616,7 +616,7 @@ phNciNfc_CoreValidateNfceeMgtCmd(pphNciNfc_CoreTxInfo_t pTxInfo,
             }
             break;
         case phNciNfc_e_NfceeMgtPowerAndLinkCtrlCmdOid:
-            if ((PHNCINFC_CORE_NFCEEMODESET_CMD_PAYLOADLEN == pTxInfo->wLen) && (NULL != pTxInfo->Buff))
+            if ((PHNCINFC_CORE_NFCEEPOWERANDLINKCTRL_CMD_PAYLOADLEN == pTxInfo->wLen) && (NULL != pTxInfo->Buff))
             {
                 wStatus = NFCSTATUS_SUCCESS;
             }

--- a/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
+++ b/libs/NfcCoreLib/lib/NciCore/phNciNfc_Core.h
@@ -543,7 +543,8 @@ typedef enum phNciNfc_CoreRfMgtNtfOid
 typedef enum phNciNfc_CoreNfceeMgtCmdOid
 {
     phNciNfc_e_NfceeMgtNfceeDiscCmdOid = 0x00,              /**<NFCEE Management NFCEE discover command OID */
-    phNciNfc_e_NfceeMgtModeSetCmdOid = 0x01                 /**<NFCEE Management NFCEE mode set command OID */
+    phNciNfc_e_NfceeMgtModeSetCmdOid = 0x01,                /**<NFCEE Management NFCEE mode set command OID */
+    phNciNfc_e_NfceeMgtPowerAndLinkCtrlCmdOid = 0x03        /**<NFCEE Management NFCEE Power And Link Control command OID */
 }phNciNfc_CoreNfceeMgtCmdOid_t ;
 
 /**
@@ -556,7 +557,8 @@ typedef enum phNciNfc_CoreNfceeMgtCmdOid
 typedef enum phNciNfc_CoreNfceeMgtRspOid
 {
     phNciNfc_e_NfceeMgtNfceeDiscRspOid = 0x00,              /**<NFCEE Management NFCEE discover response OID */
-    phNciNfc_e_NfceeMgtModeSetRspOid = 0x01                 /**<NFCEE Management NFCEE mode set response OID */
+    phNciNfc_e_NfceeMgtModeSetRspOid = 0x01,                /**<NFCEE Management NFCEE mode set response OID */
+    phNciNfc_e_NfceeMgtPowerAndLinkCtrlRspOid = 0x03        /**<NFCEE Management NFCEE Power And Link Control command OID */
 }phNciNfc_CoreNfceeMgtRspOid_t ;
 
 /**

--- a/libs/NfcCoreLib/lib/NciCore/phNciNfc_CoreUtils.c
+++ b/libs/NfcCoreLib/lib/NciCore/phNciNfc_CoreUtils.c
@@ -109,6 +109,7 @@ static NFCSTATUS phNciNfc_CoreUtilsValidateRspPktOID(uint8_t bGID, uint8_t bOID)
         {
             case phNciNfc_e_NfceeMgtNfceeDiscRspOid:
             case phNciNfc_e_NfceeMgtModeSetRspOid:
+            case phNciNfc_e_NfceeMgtPowerAndLinkCtrlRspOid:
                 bRetNfcStat = NFCSTATUS_SUCCESS;
                 break;
             default:


### PR DESCRIPTION
This pull request is adding support for the NCI2.0 command NFCEE_POWER_AND_LINK_CNTRL.
In this pull request, this command is use to request permanent power when a communication is starting over the apdu gate and release to NFCC control once done.
Out of a SWP communication, The NFCC may control eSE power for card emulation use case.