### PR TITLE
Add RF_INTERFACE_SE_SET_MODE_SEQUENCE

### DIFF
--- a/Cx/NfcCxRF.cpp
+++ b/Cx/NfcCxRF.cpp
@@ -3814,6 +3814,54 @@ Done:
     return Status;
 }
 
+_Function_class_(EVT_NFC_CX_SEQUENCE_COMPLETION_ROUTINE)
+static VOID
+NfcCxRFInterfaceSESetModeCompleteCB(
+    _In_ WDFDEVICE /*Device*/,
+    _In_ NTSTATUS Status,
+    _In_ ULONG Flags,
+    _In_ WDFCONTEXT Context
+)
+{
+    PNFCCX_RF_INTERFACE rfInterface = (PNFCCX_RF_INTERFACE)Context;
+
+    TRACE_FUNCTION_ENTRY(LEVEL_VERBOSE);
+
+    TRACE_LINE(LEVEL_INFO, "Flags=0x%x", Flags);
+
+    NfcCxRFInterfaceStopWatchdogTimer(rfInterface);
+    NfcCxInternalSequence(rfInterface, rfInterface->pSeqHandler, Status, NULL, NULL);
+
+    TRACE_FUNCTION_EXIT_NTSTATUS(LEVEL_VERBOSE, Status);
+}
+
+NTSTATUS
+NfcCxRFInterfaceSESetModeComplete(
+    _In_ PNFCCX_RF_INTERFACE RFInterface,
+    _In_ NTSTATUS Status,
+    _In_opt_ VOID* /*Param1*/,
+    _In_opt_ VOID* /*Param2*/
+)
+{
+    TRACE_FUNCTION_ENTRY(LEVEL_VERBOSE);
+
+    WdfWaitLockAcquire(RFInterface->SequenceLock, NULL);
+
+    if (RFInterface->SeqHandlers[SequenceNfceeSetModeComplete] != NULL) {
+        Status = STATUS_PENDING;
+        NfcCxRFInterfaceStartWatchdogTimer(RFInterface);
+        RFInterface->SeqHandlers[SequenceNfceeSetModeComplete](RFInterface->FdoContext->Device,
+            SequenceNfceeSetModeComplete,
+            NfcCxRFInterfaceSESetModeCompleteCB,
+            (WDFCONTEXT)RFInterface);
+    }
+
+    WdfWaitLockRelease(RFInterface->SequenceLock);
+
+    TRACE_FUNCTION_EXIT_NTSTATUS(LEVEL_VERBOSE, Status);
+    return Status;
+}
+
 static VOID
 NfcCxRFInterfaceRemoteDevSendCB(
     _In_ void* pContext,

--- a/Cx/NfcCxRF.h
+++ b/Cx/NfcCxRF.h
@@ -509,6 +509,7 @@ FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceSetDefaultRoutingTable;
 FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceDisableSecureElements;
 
 FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceSESetModeConfig;
+FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceSESetModeComplete;
 FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceSESetPowerAndLinkControl;
 FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceConfigureRoutingTable;
 
@@ -582,6 +583,7 @@ FN_NFCCX_CX_SEQUENCE_ENTRY NfcCxRFInterfaceESEGetATRStringSeq;
 
 #define RF_INTERFACE_SE_SET_MODE_SEQUENCE \
     NFCCX_CX_SEQUENCE_ENTRY(NfcCxRFInterfaceSESetModeConfig) \
+    NFCCX_CX_SEQUENCE_ENTRY(NfcCxRFInterfaceSESetModeComplete) \
     NFCCX_CX_SEQUENCE_ENTRY(NfcCxRFInterfaceSESetPowerAndLinkControl)
 
 #define RF_INTERFACE_SE_SET_ROUTING_MODE_SEQUENCE NFCCX_CX_SEQUENCE_ENTRY(NfcCxRFInterfaceConfigureRoutingTable)

--- a/inc/NfcCx.h
+++ b/inc/NfcCx.h
@@ -167,6 +167,7 @@ typedef enum _NFC_CX_SEQUENCE {
     SequenceShutdownComplete,
     SequencePreRecovery,
     SequenceRecoveryComplete,
+    SequenceNfceeSetModeComplete,
     SequenceMaximum,
 } NFC_CX_SEQUENCE, *PNFC_CX_SEQUENCE;
 


### PR DESCRIPTION
RF_INTERFACE_SE_SET_MODE_SEQUENCE is intended to allow the Nfc Client to
run additional vendor specific operation after the secure element is enabled/disabled.