### PR TITLE
Hci regression fixes

### DIFF
--- a/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.c
@@ -1171,8 +1171,8 @@ phHciNfc_ReceiveOpenPipeNotifyCmd(void *pContext,NFCSTATUS wStatus, void *pInfo)
                 wStatus = phHciNfc_CoreSend (pHciContext,&tSendParams,&phHciNfc_AnyOkCb, pHciContext);
                 if((NFCSTATUS_PENDING == wStatus))
                 {
-                    /* Do not register for events at APDU Gate Pipe */
-                    if(pReceivedParams->bPipeId != pHciContext->aGetHciSessionId[PHHCI_ESE_APDU_PIPE_STORAGE_INDEX])
+                    if(pReceivedParams->bPipeId == pHciContext->aGetHciSessionId[PHHCI_UICC_CONNECTIVITY_PIPE_STORAGE_INDEX] ||
+                       pReceivedParams->bPipeId == pHciContext->aGetHciSessionId[PHHCI_ESE_CONNECTIVITY_PIPE_STORAGE_INDEX])
                     {
                         /* Register for Evt for the opened pipe */
                         tHciRegData.eMsgType = phHciNfc_e_HciMsgTypeEvent;
@@ -1193,6 +1193,16 @@ phHciNfc_ReceiveOpenPipeNotifyCmd(void *pContext,NFCSTATUS wStatus, void *pInfo)
                         {
                             PH_LOG_HCI_CRIT_STR("No need to launch sequence");
                         }
+                    }
+                    else if (pReceivedParams->bPipeId == pHciContext->aGetHciSessionId[PHHCI_ESE_APDU_PIPE_STORAGE_INDEX])
+                    {
+                        /* Register for Evt for the opened pipe */
+                        tHciRegData.eMsgType = phHciNfc_e_HciMsgTypeEvent;
+                        tHciRegData.bPipeId = pReceivedParams->bPipeId;
+                        (void)phHciNfc_RegisterCmdRspEvt(pHciContext,
+                                               &tHciRegData,
+                                               &phHciNfc_ProcessEventsOnApduPipe,
+                                               pHciContext);
                     }
                 }
             }

--- a/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Hci.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phLibNfc_Hci.c
@@ -22,7 +22,6 @@ static NFCSTATUS phLibNfc_HciGetSessionIdentityProc(void* pContext,NFCSTATUS sta
 static NFCSTATUS phLibNfc_HciChildDevCommonInitComplete(void* pContext, NFCSTATUS status, void* pInfo);
 static NFCSTATUS phLibNfc_HciInitComplete(void* pContext,NFCSTATUS status,void* pInfo);
 static NFCSTATUS phLibNfc_HciChildDevCreateApduPipeComplete(void* pContext, NFCSTATUS status, void* pInfo);
-static NFCSTATUS phLibNfc_HciEndInitSequence(void* pContext, NFCSTATUS status, void* pInfo);
 static NFCSTATUS phLibNfc_NfceeModeSet(void *pContext,NFCSTATUS wStatus,void *pInfo);
 static NFCSTATUS phLibNfc_NfceeModeSetProc(void *pContext, NFCSTATUS wStatus, void *pInfo);
 


### PR DESCRIPTION
Hi Ivan,

Please find in the following PR fixes or cleanup based on the current changes seen on master.
The obvious regression seen on eSE non ETSIv12 compliant is that at initial activation, no registration for
APDU pipe event is done. For instance, when sending data to the APDU pipe the answer is not managed by the correct callback and is getting lost. As a consequence, it is impossible to communicate with the SE (i.e: only at initial activation). 

Best Regards
Christophe
