### PR TITLE
Fix ISO15693 formatting github issue #47

### DIFF
--- a/libs/NfcCoreLib/lib/Fri/phFriNfc_ISO15693Format.c
+++ b/libs/NfcCoreLib/lib/Fri/phFriNfc_ISO15693Format.c
@@ -378,7 +378,7 @@ phFriNfc_ISO15693_H_ProFormat (
 
                     default:
                     {
-                        result = PHNFCSTVAL (CID_FRI_NFC_NDEF_SMTCRDFMT, NFCSTATUS_INVALID_DEVICE_REQUEST);
+                        *(a_send_byte + send_index) = 0;
                         break;
                     }
                 }

--- a/libs/NfcCoreLib/lib/Fri/phFriNfc_ISO15693Format.c
+++ b/libs/NfcCoreLib/lib/Fri/phFriNfc_ISO15693Format.c
@@ -29,6 +29,8 @@
 #define ISO15693_CC_VER_RW                              0x40U
 /* CC BYTE 2 - max size is calaculated using the byte 3 multiplied by 8 */
 #define ISO15693_CC_MULTIPLE_FACTOR                     0x08U
+/* CC BYTE 3 - Additional feature information - no additional features by default (0) */
+#define ISO15693_CC_ADDITIONAL_FEATURES_NONE            0
 
 /* Inventory command support mask for the CC byte 4 */
 #define ISO15693_INVENTORY_CMD_MASK                     0x02U
@@ -378,7 +380,8 @@ phFriNfc_ISO15693_H_ProFormat (
 
                     default:
                     {
-                        *(a_send_byte + send_index) = 0;
+                        /* Generic tag: No additional features if tag type was not recognized  */
+                        *(a_send_byte + send_index) = (uint8_t) ISO15693_CC_ADDITIONAL_FEATURES_NONE;
                         break;
                     }
                 }


### PR DESCRIPTION
When NDEF formatting an ISO15693 tag, phFriNfc_ISO15693_H_ProFormat will
return NFCSTATUS_INVALID_DEVICE_REQUEST if the max_data_size does not
match ISO15693_SLI_X_MAX_SIZE or ISO15693_SLI_X_S_MAX_SIZE or
ISO15693_SLI_X_L_MAX_SIZE.

The default CC byte 3 value is now set by default to 0 so that the tag
can be NDEF formatted and used.