### PR TITLE
Add support for HCI EVT_HOT_PLUG event in order to shorter SEs activation time

### DIFF
--- a/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Interface.h
+++ b/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Interface.h
@@ -194,7 +194,8 @@ typedef enum phHciNfc_HciVersion
 {
     phHciNfc_e_HciVersionUnknown = 0x00U, // Uninitialized
     phHciNfc_e_HciVersion9 = 0x01U, // v9.0.0 - v11.2.0
-    phHciNfc_e_HciVersion12 = 0x02U, // v12.0.0+
+    phHciNfc_e_HciVersion12 = 0x02U, // v12.1.0+
+    phHciNfc_e_HciVersion15 = 0x03U, // v15.0.0+
 } phHciNfc_HciVersion_t;
 
 typedef struct phHciNfc_GateInfo

--- a/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.c
+++ b/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.c
@@ -856,9 +856,7 @@ static NFCSTATUS phHciNfc_GetPipeIndex(phHciNfc_RegInfo_t *pList,
             /* Check for Event Hot Plug */
             if(phHciNfc_e_EvtHotPlug == (phHciNfc_EvtType_t)pReceivedParams->bIns)
             {
-#if 0 /* Commented as waiting on EVENT_HOTPLUG is not required as of now */
-                (void)phLibNfc_SeEventHotPlugCb(pHciContext,wStatus,pReceivedParams);
-#endif
+                phLibNfc_SeEventHotPlugCb(pHciContext, wStatus, pReceivedParams);
                 wStatus = NFCSTATUS_SUCCESS;
             }
             else

--- a/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.h
+++ b/libs/NfcCoreLib/lib/LibNfc/phHciNfc_Pipe.h
@@ -65,6 +65,15 @@ typedef enum phNciNfc_eHciMsgType
     phHciNfc_e_HciMsgTypeRsp        /**<Hci response message type*/
 }phNciNfc_eHciMsgType_t;
 
+typedef enum phNciNfc_HciHotPlugEvtStatus
+{
+    phHciNfc_e_HciHotPlugEvtRemoved = 0,	/**<The HCI host has been removed*/
+    phHciNfc_e_HciHotPlugEvtSuccessful,    /**<The HCI host has been inserted and
+                                               lower layer idendity check has been successful*/
+    phHciNfc_e_HciHotPlugEvtFailed         /**<The HCI host has been inserted and
+                                               lower layer idendity check has failed*/
+}phNciNfc_eHciHotPlugEvtStatus_t;
+
 typedef struct phHciNfc_HciRegData
 {
     phNciNfc_eHciMsgType_t  eMsgType;
@@ -77,6 +86,12 @@ typedef struct phHciNfc_AdmPipeCreateCmdParams
     uint8_t     bDestHID;
     uint8_t     bDestGID;
 } phHciNfc_AdmPipeCreateCmdParams_t;
+
+typedef struct phHciNfc_AdmPipeHotPlugEvtParams
+{
+    uint8_t     bHostID;
+    uint8_t     bStatus;
+} phHciNfc_AdmPipeHotPlugEvtParams_t;
 
 extern NFCSTATUS
 phHciNfc_Transceive(


### PR DESCRIPTION
Hello,

This pull request propose a standard way to shorten the SE activation time window using HCI EVT_HOT_PLUG event.

ETSI v12.1 add additional parameters to EVT_HOT_PLUG in order to give a status on the activation or deactivation of a HCI host.
This allow to shorten the time to discover SEs or activate/deactivate SEs.

Best Regards
Christophe